### PR TITLE
fix: Improve device configuration handling

### DIFF
--- a/src/cloud/cloud_codec/aws_iot_codec.c
+++ b/src/cloud/cloud_codec/aws_iot_codec.c
@@ -408,6 +408,7 @@ exit:
 /* Public interface */
 int cloud_codec_decode_config(char *input, struct cloud_data_cfg *data)
 {
+	int err = 0;
 	cJSON *root_obj = NULL;
 	cJSON *group_obj = NULL;
 	cJSON *subgroup_obj = NULL;
@@ -439,11 +440,13 @@ int cloud_codec_decode_config(char *input, struct cloud_data_cfg *data)
 
 	group_obj = json_object_decode(root_obj, OBJECT_STATE);
 	if (group_obj == NULL) {
+		err = -ENODATA;
 		goto exit;
 	}
 
 	subgroup_obj = json_object_decode(group_obj, OBJECT_CONFIG);
 	if (subgroup_obj == NULL) {
+		err = -ENODATA;
 		goto exit;
 	}
 
@@ -479,9 +482,10 @@ get_data:
 	if (acc_thres != NULL) {
 		data->acct = acc_thres->valueint;
 	}
+
 exit:
 	cJSON_Delete(root_obj);
-	return 0;
+	return err;
 }
 
 int cloud_codec_encode_config(struct cloud_codec_data *output,

--- a/src/cloud/cloud_codec/azure_iot_hub_codec.c
+++ b/src/cloud/cloud_codec/azure_iot_hub_codec.c
@@ -408,7 +408,7 @@ exit:
 /* Public interface */
 int cloud_codec_decode_config(char *input, struct cloud_data_cfg *data)
 {
-	char *string = NULL;
+	int err = 0;
 	cJSON *root_obj = NULL;
 	cJSON *group_obj = NULL;
 	cJSON *subgroup_obj = NULL;
@@ -440,11 +440,13 @@ int cloud_codec_decode_config(char *input, struct cloud_data_cfg *data)
 
 	group_obj = json_object_decode(root_obj, OBJECT_DESIRED);
 	if (group_obj == NULL) {
+		err = -ENODATA;
 		goto exit;
 	}
 
 	subgroup_obj = json_object_decode(group_obj, OBJECT_CONFIG);
 	if (subgroup_obj == NULL) {
+		err = -ENODATA;
 		goto exit;
 	}
 
@@ -480,9 +482,10 @@ get_data:
 	if (acc_thres != NULL) {
 		data->acct = acc_thres->valueint;
 	}
+
 exit:
 	cJSON_Delete(root_obj);
-	return 0;
+	return err;
 }
 
 int cloud_codec_encode_config(struct cloud_codec_data *output,

--- a/src/cloud/cloud_codec/nrf_cloud_codec.c
+++ b/src/cloud/cloud_codec/nrf_cloud_codec.c
@@ -407,7 +407,7 @@ exit:
 /* Public interface */
 int cloud_codec_decode_config(char *input, struct cloud_data_cfg *data)
 {
-	char *string = NULL;
+	int err = 0;
 	cJSON *root_obj = NULL;
 	cJSON *group_obj = NULL;
 	cJSON *subgroup_obj = NULL;
@@ -440,11 +440,13 @@ int cloud_codec_decode_config(char *input, struct cloud_data_cfg *data)
 
 	group_obj = json_object_decode(root_obj, OBJECT_STATE);
 	if (group_obj == NULL) {
+		err = -ENODATA;
 		goto exit;
 	}
 
 	subgroup_obj = json_object_decode(group_obj, OBJECT_CONFIG);
 	if (subgroup_obj == NULL) {
+		err = -ENODATA;
 		goto exit;
 	}
 
@@ -480,9 +482,10 @@ get_data:
 	if (acc_thres != NULL) {
 		data->acct = acc_thres->valueint;
 	}
+
 exit:
 	cJSON_Delete(root_obj);
-	return 0;
+	return err;
 }
 
 int cloud_codec_encode_config(struct cloud_codec_data *output,

--- a/src/main.c
+++ b/src/main.c
@@ -335,13 +335,6 @@ static void on_sub_state_active(struct app_msg_data *msg)
 
 static void on_state_running(struct app_msg_data *msg)
 {
-	/* Always send the device configuration upon a
-	 * established connection to cloud.
-	 */
-	if (IS_EVENT(msg, cloud, CLOUD_MGR_EVT_CONNECTED)) {
-		config_send();
-	}
-
 	if (IS_EVENT(msg, modem, MODEM_MGR_EVT_DATE_TIME_OBTAINED)) {
 		data_get_init();
 	}

--- a/src/managers/cloud_manager.c
+++ b/src/managers/cloud_manager.c
@@ -459,6 +459,13 @@ static void cloud_wrap_event_handler(const struct cloud_wrap_event *const evt)
 
 			EVENT_SUBMIT(cloud_mgr_event);
 			break;
+		} else if (err == -ENODATA) {
+			LOG_WRN("Device configuration empty!");
+		} else {
+			LOG_ERR("Decoding of device configuration, error: %d",
+				err);
+			signal_error(err);
+			break;
 		}
 
 		// Perhaps DBG level logging here


### PR DESCRIPTION
 - Do not acknowledge device configuration to cloud if it is identical
   to the devices copy.
 - Add more descriptive logging on decoding/encoding of device
   configuration.
 - Do not publish configuration for every connection to cloud. Depend
   on the desired state and the initial device state getting in each
   cloud backend.
