### PR TITLE
fix: remove prefix from static functions in managers.

### DIFF
--- a/src/managers/cloud_manager.c
+++ b/src/managers/cloud_manager.c
@@ -114,7 +114,7 @@ static void signal_data_ack(void *ptr)
 	EVENT_SUBMIT(cloud_mgr_event);
 }
 
-static void cloud_manager_data_send(struct data_mgr_event *evt)
+static void data_send(struct data_mgr_event *evt)
 {
 	int err;
 
@@ -130,7 +130,7 @@ static void cloud_manager_data_send(struct data_mgr_event *evt)
 	}
 }
 
-static void cloud_manager_config_send(struct data_mgr_event *evt)
+static void config_send(struct data_mgr_event *evt)
 {
 	int err;
 
@@ -146,7 +146,7 @@ static void cloud_manager_config_send(struct data_mgr_event *evt)
 	}
 }
 
-static void cloud_manager_config_get(void)
+static void config_get(void)
 {
 	int err;
 
@@ -158,7 +158,7 @@ static void cloud_manager_config_get(void)
 	}
 }
 
-static void cloud_manager_batch_data_send(struct data_mgr_event *evt)
+static void batch_data_send(struct data_mgr_event *evt)
 {
 	int err;
 
@@ -174,7 +174,7 @@ static void cloud_manager_batch_data_send(struct data_mgr_event *evt)
 	}
 }
 
-static void cloud_manager_ui_data_send(struct data_mgr_event *evt)
+static void ui_data_send(struct data_mgr_event *evt)
 {
 	int err;
 
@@ -216,7 +216,9 @@ static void connect_cloud(void)
 
 	connect_retries++;
 
-	LOG_WRN("New connection attempt in %d seconds", backoff_sec);
+	LOG_WRN("Cloud connection establishment in progress");
+	LOG_WRN("New connection attempt in %d seconds if not successful",
+		backoff_sec);
 
 	/* Start timer to check connection status after backoff */
 	k_delayed_work_submit(&connect_check_work, K_SECONDS(backoff_sec));
@@ -361,23 +363,23 @@ static void on_sub_state_cloud_connected(struct cloud_msg_data *msg)
 #endif /* CONFIG_AGPS && CONFIG_AGPS_SRC_NRF_CLOUD */
 
 	if (IS_EVENT(msg, data, DATA_MGR_EVT_DATA_SEND)) {
-		cloud_manager_data_send(&msg->manager.data);
+		data_send(&msg->manager.data);
 	}
 
 	if (IS_EVENT(msg, data, DATA_MGR_EVT_CONFIG_SEND)) {
-		cloud_manager_config_send(&msg->manager.data);
+		config_send(&msg->manager.data);
 	}
 
 	if (IS_EVENT(msg, data, DATA_MGR_EVT_CONFIG_GET)) {
-		cloud_manager_config_get();
+		config_get();
 	}
 
 	if (IS_EVENT(msg, data, DATA_MGR_EVT_DATA_SEND_BATCH)) {
-		cloud_manager_batch_data_send(&msg->manager.data);
+		batch_data_send(&msg->manager.data);
 	}
 
 	if (IS_EVENT(msg, data, DATA_MGR_EVT_UI_DATA_SEND)) {
-		cloud_manager_ui_data_send(&msg->manager.data);
+		ui_data_send(&msg->manager.data);
 	}
 }
 
@@ -503,7 +505,7 @@ static void cloud_wrap_event_handler(const struct cloud_wrap_event *const evt)
 	}
 }
 
-static int cloud_manager_setup(void)
+static int setup(void)
 {
 	int err;
 
@@ -534,9 +536,9 @@ static void cloud_manager(void)
 
 	k_delayed_work_init(&connect_check_work, connect_check_work_fn);
 
-	err = cloud_manager_setup();
+	err = setup();
 	if (err) {
-		LOG_ERR("cloud_manager_setup, error %d", err);
+		LOG_ERR("setup, error %d", err);
 		signal_error(err);
 	}
 

--- a/src/managers/data_manager.c
+++ b/src/managers/data_manager.c
@@ -221,7 +221,7 @@ static int save_config(const void *buf, size_t buf_len)
 	return 0;
 }
 
-static int data_manager_setup(void)
+static int setup(void)
 {
 	int err;
 
@@ -802,9 +802,9 @@ static void data_manager(void)
 
 	atomic_inc(&manager_count);
 
-	err = data_manager_setup();
+	err = setup();
 	if (err) {
-		LOG_ERR("data_manager_setup, error: %d", err);
+		LOG_ERR("setup, error: %d", err);
 		signal_error(err);
 	}
 

--- a/src/managers/modem_manager.c
+++ b/src/managers/modem_manager.c
@@ -258,7 +258,7 @@ static void check_modem_fw_version(void)
 	modem_fw_version_checked = true;
 }
 
-static int modem_manager_modem_data_get(void)
+static int modem_data_get(void)
 {
 	int err;
 
@@ -326,7 +326,7 @@ static bool battery_data_requested(enum app_mgr_data_type *data_list,
 	return false;
 }
 
-static int modem_manager_battery_data_get(void)
+static int battery_data_get(void)
 {
 	int err;
 
@@ -538,7 +538,7 @@ static void on_all_states(struct modem_msg_data *msg)
 
 			int err;
 
-			err = modem_manager_modem_data_get();
+			err = modem_data_get();
 			if (err) {
 				signal_error(err);
 			}
@@ -549,7 +549,7 @@ static void on_all_states(struct modem_msg_data *msg)
 
 			int err;
 
-			err = modem_manager_battery_data_get();
+			err = battery_data_get();
 			if (err) {
 				signal_error(err);
 			}

--- a/src/managers/output_manager.c
+++ b/src/managers/output_manager.c
@@ -64,7 +64,7 @@ static struct k_delayed_work led_pat_gps_work;
 
 K_MSGQ_DEFINE(msgq_output, sizeof(struct output_msg_data), 10, 4);
 
-static void output_manager(struct output_msg_data *msg);
+static void message_handler(struct output_msg_data *msg);
 
 static void signal_error(int err)
 {
@@ -76,7 +76,7 @@ static void signal_error(int err)
 	EVENT_SUBMIT(output_mgr_event);
 }
 
-static int output_manager_setup(void)
+static int setup(void)
 {
 	int err;
 
@@ -123,9 +123,9 @@ static bool event_handler(const struct event_header *eh)
 			k_delayed_work_init(&led_pat_passive_work,
 					    led_pat_passive_work_fn);
 
-			err = output_manager_setup();
+			err = setup();
 			if (err) {
-				LOG_ERR("output_manager_setup, error: %d", err);
+				LOG_ERR("setup, error: %d", err);
 				signal_error(err);
 			}
 		}
@@ -137,7 +137,7 @@ static bool event_handler(const struct event_header *eh)
 			.manager.data = *event
 		};
 
-		output_manager(&output_msg);
+		message_handler(&output_msg);
 	}
 
 	if (is_modem_mgr_event(eh)) {
@@ -146,7 +146,7 @@ static bool event_handler(const struct event_header *eh)
 			.manager.modem = *event
 		};
 
-		output_manager(&output_msg);
+		message_handler(&output_msg);
 	}
 
 	if (is_gps_mgr_event(eh)) {
@@ -155,7 +155,7 @@ static bool event_handler(const struct event_header *eh)
 			.manager.gps = *event
 		};
 
-		output_manager(&output_msg);
+		message_handler(&output_msg);
 	}
 
 	if (is_util_mgr_event(eh)) {
@@ -164,7 +164,7 @@ static bool event_handler(const struct event_header *eh)
 			.manager.util = *event
 		};
 
-		output_manager(&output_msg);
+		message_handler(&output_msg);
 	}
 
 	return false;
@@ -350,7 +350,7 @@ static void on_all_states(struct output_msg_data *output_msg)
 	}
 }
 
-static void output_manager(struct output_msg_data *msg)
+static void message_handler(struct output_msg_data *msg)
 {
 	switch (output_state) {
 	case OUTPUT_MGR_STATE_INIT:

--- a/src/managers/ui_manager.c
+++ b/src/managers/ui_manager.c
@@ -87,7 +87,7 @@ static void button_handler(uint32_t button_states, uint32_t has_changed)
 #endif
 }
 
-static int ui_manager_setup(void)
+static int setup(void)
 {
 	int err;
 
@@ -107,9 +107,9 @@ static void message_handler(struct ui_msg_data *msg)
 
 		atomic_inc(&manager_count);
 
-		err = ui_manager_setup();
+		err = setup();
 		if (err) {
-			LOG_ERR("ui_manager_setup, error: %d", err);
+			LOG_ERR("setup, error: %d", err);
 			signal_error(err);
 		}
 	}

--- a/src/managers/util_manager.c
+++ b/src/managers/util_manager.c
@@ -188,7 +188,7 @@ static bool event_handler(const struct event_header *eh)
 	return false;
 }
 
-static void state_agnostic_manager_events(struct util_msg_data *msg)
+static void on_all_states(struct util_msg_data *msg)
 {
 	static int reboot_ack_cnt;
 
@@ -204,10 +204,6 @@ static void state_agnostic_manager_events(struct util_msg_data *msg)
 		default:
 			break;
 		}
-	}
-
-	if (IS_EVENT(msg, cloud, CLOUD_MGR_EVT_ERROR)) {
-
 	}
 
 	if (is_modem_mgr_event(&msg->manager.modem.header)) {
@@ -319,7 +315,7 @@ static void message_handler(struct util_msg_data *msg)
 	}
 
 
-	state_agnostic_manager_events(msg);
+	on_all_states(msg);
 }
 
 EVENT_LISTENER(MODULE, event_handler);


### PR DESCRIPTION
 - remove prefixes
 - Update log output when connecting to cloud.
