### PR TITLE
modules_common: Add and apply common functions for modules

### DIFF
--- a/src/events/app_mgr_event.c
+++ b/src/events/app_mgr_event.c
@@ -73,7 +73,7 @@ static int log_app_mgr_event(const struct event_header *eh, char *buf,
 	case APP_MGR_EVT_ERROR:
 		strcpy(event_name, "APP_MGR_EVT_ERROR");
 		return snprintf(buf, buf_len, "%s - Error code %d",
-				event_name, event->err);
+				event_name, event->data.err);
 	default:
 		strcpy(event_name, "Unknown event");
 		break;

--- a/src/events/app_mgr_event.h
+++ b/src/events/app_mgr_event.h
@@ -81,7 +81,9 @@ struct app_mgr_event {
 	enum app_mgr_event_type type;
 	enum app_mgr_data_type data_list[APP_DATA_COUNT];
 
-	int err;
+	union {
+		int err;
+	} data;
 
 	size_t count;
 

--- a/src/events/output_mgr_event.c
+++ b/src/events/output_mgr_event.c
@@ -21,7 +21,7 @@ static int log_output_mgr_event(const struct event_header *eh, char *buf,
 	case OUTPUT_MGR_EVT_ERROR:
 		strcpy(event_name, "OUTPUT_MGR_EVT_ERROR");
 		return snprintf(buf, buf_len, "%s - Error code %d",
-				event_name, event->err);
+				event_name, event->data.err);
 	default:
 		strcpy(event_name, "Unknown event");
 		break;

--- a/src/events/output_mgr_event.h
+++ b/src/events/output_mgr_event.h
@@ -29,7 +29,9 @@ enum output_mgr_event_types {
 struct output_mgr_event {
 	struct event_header header;
 	enum output_mgr_event_types type;
-	int err;
+	union {
+		int err;
+	} data;
 };
 
 EVENT_TYPE_DECLARE(output_mgr_event);

--- a/src/managers/modules_common.c
+++ b/src/managers/modules_common.c
@@ -8,7 +8,13 @@
 
 #include "modules_common.h"
 
-inline int module_get_next_msg(struct module_data *module, void *msg)
+#include <logging/log.h>
+
+LOG_MODULE_REGISTER(modules_common, CONFIG_CAT_TRACKER_LOG_LEVEL);
+
+static atomic_t active_module_count;
+
+int module_get_next_msg(struct module_data *module, void *msg)
 {
 	return k_msgq_get(module->msg_q, msg, K_FOREVER);
 }
@@ -18,8 +24,22 @@ void module_enqueue_msg(struct module_data *module, void *msg)
 	while (k_msgq_put(module->msg_q, msg, K_NO_WAIT) != 0) {
 		/* Message queue is full: purge old data & try again */
 		k_msgq_purge(module->msg_q);
-		printk("Message queue full, queue purged\n");
+		LOG_WRN("Message queue full, queue purged");
 	}
 }
 
-// void module_start()
+void module_start(struct module_data *module)
+{
+	atomic_inc(&active_module_count);
+
+	if (module->name) {
+		LOG_DBG("Module \"%s\" started", module->name);
+	} else if (module->thread_id) {
+		LOG_DBG("Module with thread ID %p started", module->thread_id);
+	}
+}
+
+uint32_t module_active_count_get(void)
+{
+	return atomic_get(&active_module_count);
+}

--- a/src/managers/modules_common.h
+++ b/src/managers/modules_common.h
@@ -11,17 +11,37 @@
 		is_ ## _mgr ## _mgr_event(&_ptr->manager._mgr.header) && \
 		_ptr->manager._mgr.type == _evt
 
+#define SEND_EVENT(_mgr, _type)					      \
+	struct _mgr ## _mgr_event *event = new_ ## _mgr ## _mgr_event();      \
+	event->type = _type;						      \
+	EVENT_SUBMIT(event)
+
+#define SEND_ERROR(_mgr, _type, _error_code)				      \
+	struct _mgr ## _mgr_event *event = new_ ## _mgr ## _mgr_event();      \
+	event->type = _type;						      \
+	event->data.err = _error_code;					      \
+	EVENT_SUBMIT(event)
 
 struct module_data {
-	// Storing only thread ID here. Assume stack is kept static in module.
 	k_tid_t thread_id;
-
-	// Queue is kept outside of struct
+	char *name;
 	struct k_msgq *msg_q;
 };
+
+void module_register(struct module_data *module);
+
+void module_set_thread(struct module_data *module, const k_tid_t thread_id);
+
+void module_set_name(struct module_data *module, char *name);
+
+void module_set_queue(struct module_data *module,  struct k_msgq *msg_q);
 
 int module_get_next_msg(struct module_data *module, void *msg);
 
 void module_enqueue_msg(struct module_data *module, void *msg);
+
+void module_start(struct module_data *module);
+
+uint32_t module_active_count_get(void);
 
 #endif /* _MODULES_COMMON_H_ */

--- a/src/managers/util_manager.c
+++ b/src/managers/util_manager.c
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (c) 2020 Nordic Semiconductor ASA
  *
@@ -25,10 +24,9 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(MODULE, CONFIG_CAT_TRACKER_LOG_LEVEL);
 
-/* Atomic variable that is incremented by other managers in the application.
- * Used to keep track of shutdown request acknowledgments from managers.
- */
-atomic_t manager_count;
+static struct module_data self = {
+	.name = "util",
+};
 
 /* Util manager states. */
 static enum util_state {
@@ -77,7 +75,7 @@ static void reboot_work_fn(struct k_work *work)
 	reboot();
 }
 
-static void signal_reboot_request(void)
+static void send_reboot_request(void)
 {
 	/* Flag ensuring that multiple reboot requests are not emitted
 	 * upon an error from multiple managers.
@@ -100,7 +98,7 @@ static void signal_reboot_request(void)
 
 void bsd_recoverable_error_handler(uint32_t err)
 {
-	signal_reboot_request();
+	send_reboot_request();
 }
 
 void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *esf)
@@ -108,7 +106,7 @@ void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *esf)
 	ARG_UNUSED(esf);
 
 	LOG_PANIC();
-	signal_reboot_request();
+	send_reboot_request();
 }
 
 static bool event_handler(const struct event_header *eh)
@@ -196,7 +194,7 @@ static void on_all_states(struct util_msg_data *msg)
 		switch (msg->manager.cloud.type) {
 		case CLOUD_MGR_EVT_ERROR: /* Fall-through */
 		case CLOUD_MGR_EVT_FOTA_DONE:
-			signal_reboot_request();
+			send_reboot_request();
 			break;
 		case CLOUD_MGR_EVT_SHUTDOWN_READY:
 			reboot_ack_cnt++;
@@ -209,7 +207,7 @@ static void on_all_states(struct util_msg_data *msg)
 	if (is_modem_mgr_event(&msg->manager.modem.header)) {
 		switch (msg->manager.modem.type) {
 		case MODEM_MGR_EVT_ERROR:
-			signal_reboot_request();
+			send_reboot_request();
 			break;
 		case MODEM_MGR_EVT_SHUTDOWN_READY:
 			reboot_ack_cnt++;
@@ -222,7 +220,7 @@ static void on_all_states(struct util_msg_data *msg)
 	if (is_sensor_mgr_event(&msg->manager.sensor.header)) {
 		switch (msg->manager.sensor.type) {
 		case SENSOR_MGR_EVT_ERROR:
-			signal_reboot_request();
+			send_reboot_request();
 			break;
 		case SENSOR_MGR_EVT_SHUTDOWN_READY:
 			reboot_ack_cnt++;
@@ -235,7 +233,7 @@ static void on_all_states(struct util_msg_data *msg)
 	if (is_gps_mgr_event(&msg->manager.gps.header)) {
 		switch (msg->manager.gps.type) {
 		case GPS_MGR_EVT_ERROR:
-			signal_reboot_request();
+			send_reboot_request();
 			break;
 		case GPS_MGR_EVT_SHUTDOWN_READY:
 			reboot_ack_cnt++;
@@ -248,7 +246,7 @@ static void on_all_states(struct util_msg_data *msg)
 	if (is_data_mgr_event(&msg->manager.data.header)) {
 		switch (msg->manager.data.type) {
 		case DATA_MGR_EVT_ERROR:
-			signal_reboot_request();
+			send_reboot_request();
 			break;
 		case DATA_MGR_EVT_SHUTDOWN_READY:
 			reboot_ack_cnt++;
@@ -261,7 +259,7 @@ static void on_all_states(struct util_msg_data *msg)
 	if (is_app_mgr_event(&msg->manager.app.header)) {
 		switch (msg->manager.app.type) {
 		case APP_MGR_EVT_ERROR:
-			signal_reboot_request();
+			send_reboot_request();
 			break;
 		case APP_MGR_EVT_SHUTDOWN_READY:
 			reboot_ack_cnt++;
@@ -274,7 +272,7 @@ static void on_all_states(struct util_msg_data *msg)
 	if (is_ui_mgr_event(&msg->manager.ui.header)) {
 		switch (msg->manager.ui.type) {
 		case UI_MGR_EVT_ERROR:
-			signal_reboot_request();
+			send_reboot_request();
 			break;
 		case UI_MGR_EVT_SHUTDOWN_READY:
 			reboot_ack_cnt++;
@@ -287,7 +285,7 @@ static void on_all_states(struct util_msg_data *msg)
 	if (is_output_mgr_event(&msg->manager.output.header)) {
 		switch (msg->manager.output.type) {
 		case OUTPUT_MGR_EVT_ERROR:
-			signal_reboot_request();
+			send_reboot_request();
 			break;
 		case OUTPUT_MGR_EVT_SHUTDOWN_READY:
 			reboot_ack_cnt++;
@@ -301,7 +299,7 @@ static void on_all_states(struct util_msg_data *msg)
 	 * that the application is ready to shutdown. This ensures a graceful
 	 * shutdown.
 	 */
-	if (reboot_ack_cnt >= manager_count) {
+	if (reboot_ack_cnt >= module_active_count_get()) {
 		k_delayed_work_submit(&reboot_work,
 				      K_SECONDS(50));
 	}
@@ -312,6 +310,7 @@ static void message_handler(struct util_msg_data *msg)
 	if (IS_EVENT(msg, app, APP_MGR_EVT_START)) {
 		state_set(STATE_INIT);
 		k_delayed_work_init(&reboot_work, reboot_work_fn);
+		module_start(&self);
 	}
 
 


### PR DESCRIPTION
Add common functions and macros for all modules.
- SEND_EVENT() macro to send event without payload
- SEND_ERROR() macro to send error event with error code
- module_start() to indicate that a module is starting
- module_active_count_get()

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>