### PR TITLE
Add state helper functions to modules

### DIFF
--- a/src/modules/output_module.c
+++ b/src/modules/output_module.c
@@ -39,23 +39,23 @@ struct output_msg_data {
 };
 
 /* Output module super states. */
-enum output_module_states {
+enum output_module_state_type {
 	OUTPUT_STATE_INIT,
 	OUTPUT_STATE_RUNNING,
 	OUTPUT_STATE_ERROR
-} output_state;
+} state;
 
 /* Output module sub states. */
-enum output_module_sub_states {
+enum output_module_sub_state_type {
 	OUTPUT_SUB_STATE_ACTIVE,
 	OUTPUT_SUB_STATE_PASSIVE
-} output_sub_state;
+} sub_state;
 
 /* Output module sub-sub states. */
-enum output_module_sub_sub_states {
+enum output_module_sub_sub_state_type {
 	OUTPUT_SUB_SUB_STATE_GPS_INACTIVE,
 	OUTPUT_SUB_SUB_STATE_GPS_ACTIVE
-} output_sub_sub_state;
+} sub_sub_state;
 
 /* Delayed works that is used to make sure the device always reverts back to the
  * device mode or GPS search LED pattern.
@@ -67,6 +67,87 @@ static struct k_delayed_work led_pat_gps_work;
 K_MSGQ_DEFINE(msgq_output, sizeof(struct output_msg_data), 10, 4);
 
 static void message_handler(struct output_msg_data *msg);
+
+static char *state2str(enum output_module_state_type state)
+{
+	switch (state) {
+	case OUTPUT_STATE_INIT:
+		return "OUTPUT_STATE_INIT";
+	case OUTPUT_STATE_RUNNING:
+		return "OUTPUT_STATE_RUNNING";
+	case OUTPUT_STATE_ERROR:
+		return "OUTPUT_STATE_ERROR";
+	default:
+		return "Unknown";
+	}
+}
+
+static char *sub_state2str(enum output_module_sub_state_type state)
+{
+	switch (state) {
+	case OUTPUT_SUB_STATE_ACTIVE:
+		return "OUTPUT_SUB_STATE_ACTIVE";
+	case OUTPUT_SUB_STATE_PASSIVE:
+		return "OUTPUT_SUB_STATE_PASSIVE";
+	default:
+		return "Unknown";
+	}
+}
+
+static char *sub_sub_state2str(enum output_module_sub_sub_state_type state)
+{
+	switch (state) {
+	case OUTPUT_SUB_SUB_STATE_GPS_INACTIVE:
+		return "OUTPUT_SUB_SUB_STATE_GPS_INACTIVE";
+	case OUTPUT_SUB_SUB_STATE_GPS_ACTIVE:
+		return "OUTPUT_SUB_SUB_STATE_GPS_ACTIVE";
+	default:
+		return "Unknown";
+	}
+}
+
+static void state_set(enum output_module_state_type new_state)
+{
+	if (new_state == state) {
+		LOG_DBG("State: %s", log_strdup(state2str(state)));
+		return;
+	}
+
+	LOG_DBG("State transition %s --> %s",
+		log_strdup(state2str(state)),
+		log_strdup(state2str(new_state)));
+
+	state = new_state;
+}
+
+static void sub_state_set(enum output_module_sub_state_type new_state)
+{
+	if (new_state == sub_state) {
+		LOG_DBG("State: %s", log_strdup(sub_state2str(sub_state)));
+		return;
+	}
+
+	LOG_DBG("State transition %s --> %s",
+		log_strdup(sub_state2str(sub_state)),
+		log_strdup(sub_state2str(new_state)));
+
+	sub_state = new_state;
+}
+
+static void sub_sub_state_set(enum output_module_sub_sub_state_type new_state)
+{
+	if (new_state == sub_sub_state) {
+		LOG_DBG("State: %s",
+			log_strdup(sub_sub_state2str(sub_sub_state)));
+		return;
+	}
+
+	LOG_DBG("State transition %s --> %s",
+		log_strdup(sub_sub_state2str(sub_sub_state)),
+		log_strdup(sub_sub_state2str(new_state)));
+
+	sub_sub_state = new_state;
+}
 
 static int setup(void)
 {
@@ -150,10 +231,10 @@ static void on_state_init(struct output_msg_data *output_msg)
 {
 	if (is_data_module_event(&output_msg->module.data.header) &&
 	    output_msg->module.data.type == DATA_EVT_CONFIG_INIT) {
-		output_state = OUTPUT_STATE_RUNNING;
-		output_sub_state = output_msg->module.data.data.cfg.act ?
-						OUTPUT_SUB_STATE_ACTIVE :
-						OUTPUT_SUB_STATE_PASSIVE;
+		state_set(OUTPUT_STATE_RUNNING);
+		sub_state_set(output_msg->module.data.data.cfg.act ?
+			      OUTPUT_SUB_STATE_ACTIVE :
+			      OUTPUT_SUB_STATE_PASSIVE);
 	}
 }
 
@@ -163,8 +244,7 @@ static void on_active_gps_active(struct output_msg_data *output_msg)
 		switch (output_msg->module.gps.type) {
 		case GPS_EVT_INACTIVE:
 			ui_led_set_pattern(UI_LED_ACTIVE_MODE);
-			output_sub_sub_state =
-					OUTPUT_SUB_SUB_STATE_GPS_INACTIVE;
+			sub_sub_state_set(OUTPUT_SUB_SUB_STATE_GPS_INACTIVE);
 			break;
 		default:
 			break;
@@ -191,8 +271,7 @@ static void on_active_gps_inactive(struct output_msg_data *output_msg)
 		switch (output_msg->module.gps.type) {
 		case GPS_EVT_ACTIVE:
 			ui_led_set_pattern(UI_LED_GPS_SEARCHING);
-			output_sub_sub_state =
-					OUTPUT_SUB_SUB_STATE_GPS_ACTIVE;
+			sub_sub_state_set(OUTPUT_SUB_SUB_STATE_GPS_ACTIVE);
 			break;
 		default:
 			break;
@@ -220,8 +299,7 @@ static void on_passive_gps_active(struct output_msg_data *output_msg)
 		switch (output_msg->module.gps.type) {
 		case GPS_EVT_INACTIVE:
 			ui_led_set_pattern(UI_LED_PASSIVE_MODE);
-			output_sub_sub_state =
-					OUTPUT_SUB_SUB_STATE_GPS_INACTIVE;
+			sub_sub_state_set(OUTPUT_SUB_SUB_STATE_GPS_INACTIVE);
 			break;
 		default:
 			break;
@@ -248,8 +326,7 @@ static void on_passive_gps_inactive(struct output_msg_data *output_msg)
 		switch (output_msg->module.gps.type) {
 		case GPS_EVT_ACTIVE:
 			ui_led_set_pattern(UI_LED_GPS_SEARCHING);
-			output_sub_sub_state =
-					OUTPUT_SUB_SUB_STATE_GPS_ACTIVE;
+			sub_sub_state_set(OUTPUT_SUB_SUB_STATE_GPS_ACTIVE);
 			break;
 		default:
 			break;
@@ -277,7 +354,7 @@ static void on_sub_state_active(struct output_msg_data *output_msg)
 		switch (output_msg->module.data.type) {
 		case DATA_EVT_CONFIG_READY:
 			if (!output_msg->module.data.data.cfg.act) {
-				output_sub_state = OUTPUT_SUB_STATE_PASSIVE;
+				sub_state_set(OUTPUT_SUB_STATE_PASSIVE);
 			}
 			break;
 		default:
@@ -290,7 +367,7 @@ static void on_sub_state_passive(struct output_msg_data *msg)
 {
 	if (IS_EVENT(msg, data, DATA_EVT_CONFIG_READY)) {
 		if (msg->module.data.data.cfg.act) {
-			output_sub_state = OUTPUT_SUB_STATE_ACTIVE;
+			sub_state_set(OUTPUT_SUB_STATE_ACTIVE);
 		}
 	}
 }
@@ -308,6 +385,11 @@ static void on_all_states(struct output_msg_data *msg)
 		int err;
 
 		module_start(&self);
+
+		state_set(OUTPUT_STATE_INIT);
+		sub_state_set(OUTPUT_SUB_STATE_ACTIVE);
+		sub_sub_state_set(OUTPUT_SUB_SUB_STATE_GPS_INACTIVE);
+
 		k_delayed_work_init(&led_pat_gps_work,
 					led_pat_gps_work_fn);
 		k_delayed_work_init(&led_pat_active_work,
@@ -325,7 +407,7 @@ static void on_all_states(struct output_msg_data *msg)
 	if (IS_EVENT(msg, util, UTIL_EVT_SHUTDOWN_REQUEST)) {
 		ui_led_set_pattern(UI_LED_ERROR_SYSTEM_FAULT);
 
-		output_state = OUTPUT_STATE_ERROR;
+		state_set(OUTPUT_STATE_ERROR);
 
 		SEND_EVENT(output, OUTPUT_EVT_SHUTDOWN_READY);
 	}
@@ -333,14 +415,14 @@ static void on_all_states(struct output_msg_data *msg)
 
 static void message_handler(struct output_msg_data *msg)
 {
-	switch (output_state) {
+	switch (state) {
 	case OUTPUT_STATE_INIT:
 		on_state_init(msg);
 		break;
 	case OUTPUT_STATE_RUNNING:
-		switch (output_sub_state) {
+		switch (sub_state) {
 		case OUTPUT_SUB_STATE_ACTIVE:
-			switch (output_sub_sub_state) {
+			switch (sub_sub_state) {
 			case OUTPUT_SUB_SUB_STATE_GPS_ACTIVE:
 				on_active_gps_active(msg);
 				break;
@@ -354,7 +436,7 @@ static void message_handler(struct output_msg_data *msg)
 			on_sub_state_active(msg);
 			break;
 		case OUTPUT_SUB_STATE_PASSIVE:
-			switch (output_sub_sub_state) {
+			switch (sub_sub_state) {
 			case OUTPUT_SUB_SUB_STATE_GPS_ACTIVE:
 				on_passive_gps_active(msg);
 				break;

--- a/src/modules/sensor_module.c
+++ b/src/modules/sensor_module.c
@@ -33,9 +33,9 @@ struct sensor_msg_data {
 };
 
 /* Sensor module super states. */
-enum sensor_module_state_type {
-	SENSOR_STATE_INIT,
-	SENSOR_STATE_RUNNING
+static enum state_type {
+	STATE_INIT,
+	STATE_RUNNING
 } state;
 
 K_MSGQ_DEFINE(msgq_sensor, sizeof(struct sensor_msg_data), 10, 4);
@@ -45,19 +45,19 @@ static struct module_data self = {
 	.msg_q = &msgq_sensor,
 };
 
-static char *state2str(enum sensor_module_state_type state)
+static char *state2str(enum state_type new_state)
 {
-	switch (state) {
-	case SENSOR_STATE_INIT:
-		return "SENSOR_STATE_INIT";
-	case SENSOR_STATE_RUNNING:
-		return "SENSOR_STATE_RUNNING";
+	switch (new_state) {
+	case STATE_INIT:
+		return "STATE_INIT";
+	case STATE_RUNNING:
+		return "STATE_RUNNING";
 	default:
 		return "Unknown";
 	}
 }
 
-static void state_set(enum sensor_module_state_type new_state)
+static void state_set(enum state_type new_state)
 {
 	if (new_state == state) {
 		LOG_DBG("State: %s", log_strdup(state2str(state)));
@@ -226,7 +226,7 @@ static void on_state_init(struct sensor_msg_data *msg)
 
 		ext_sensors_mov_thres_set(movement_threshold);
 #endif
-		state_set(SENSOR_STATE_RUNNING);
+		state_set(STATE_RUNNING);
 	}
 }
 
@@ -275,7 +275,7 @@ static void sensor_module(void)
 
 	module_start(&self);
 
-	state_set(SENSOR_STATE_INIT);
+	state_set(STATE_INIT);
 
 	err = setup();
 	if (err) {
@@ -287,10 +287,10 @@ static void sensor_module(void)
 		module_get_next_msg(&self, &msg);
 
 		switch (state) {
-		case SENSOR_STATE_INIT:
+		case STATE_INIT:
 			on_state_init(&msg);
 			break;
-		case SENSOR_STATE_RUNNING:
+		case STATE_RUNNING:
 			on_state_running(&msg);
 			break;
 		default:

--- a/src/modules/util_module.c
+++ b/src/modules/util_module.c
@@ -29,24 +29,24 @@ static struct module_data self = {
 };
 
 /* Util module states. */
-static enum util_module_state_type {
-	UTIL_STATE_INIT,
-	UTIL_STATE_REBOOT_PENDING
+static enum state_type {
+	STATE_INIT,
+	STATE_REBOOT_PENDING
 } state;
 
-static char *state2str(enum util_module_state_type state)
+static char *state2str(enum state_type new_state)
 {
-	switch (state) {
-	case UTIL_STATE_INIT:
-		return "UTIL_STATE_INIT";
-	case UTIL_STATE_REBOOT_PENDING:
-		return "UTIL_STATE_REBOOT_PENDING";
+	switch (new_state) {
+	case STATE_INIT:
+		return "STATE_INIT";
+	case STATE_REBOOT_PENDING:
+		return "STATE_REBOOT_PENDING";
 	default:
 		return "Unknown";
 	}
 }
 
-static void state_set(enum util_module_state_type new_state)
+static void state_set(enum state_type new_state)
 {
 	if (new_state == state) {
 		LOG_DBG("State: %s", log_strdup(state2str(state)));
@@ -332,7 +332,7 @@ static void message_handler(struct util_msg_data *msg)
 {
 	if (IS_EVENT(msg, app, APP_EVT_START)) {
 		module_start(&self);
-		state_set(UTIL_STATE_INIT);
+		state_set(STATE_INIT);
 		k_delayed_work_init(&reboot_work, reboot_work_fn);
 	}
 


### PR DESCRIPTION
 - Align modules with 'equal' set of helper function that
   sets states and substates, aswell as handles printing of state
   transitions.

 - Remove prefix from state variables and enums in managers

