### PR TITLE
modules_common: Add logging of message processing

### DIFF
--- a/src/modules/modules_common.c
+++ b/src/modules/modules_common.c
@@ -5,18 +5,39 @@
  */
 
 #include <zephyr.h>
-
+#include <event_manager.h>
 #include "modules_common.h"
 
 #include <logging/log.h>
 
-LOG_MODULE_REGISTER(modules_common, CONFIG_APPLICATION_MODULE_LOG_LEVEL);
+LOG_MODULE_REGISTER(modules_common, CONFIG_MODULES_COMMON_LOG_LEVEL);
+
+struct event_prototype {
+	struct event_header header;
+	uint8_t event_id;
+};
 
 static atomic_t active_module_count;
 
 int module_get_next_msg(struct module_data *module, void *msg)
 {
-	return k_msgq_get(module->msg_q, msg, K_FOREVER);
+	int err = k_msgq_get(module->msg_q, msg, K_FOREVER);
+
+	if (err == 0 && IS_ENABLED(CONFIG_MODULES_COMMON_LOG_LEVEL_DBG)) {
+		struct event_prototype *evt_proto =
+			(struct event_prototype *)msg;
+		struct event_type *event =
+			(struct event_type *)evt_proto->header.type_id;
+		char buf[50];
+
+		event->log_event(&evt_proto->header, buf, sizeof(buf));
+
+		LOG_DBG("%s module: Dequeued %s",
+			log_strdup(module->name),
+			log_strdup(buf));
+	}
+
+	return err;
 }
 
 void module_enqueue_msg(struct module_data *module, void *msg)
@@ -24,7 +45,21 @@ void module_enqueue_msg(struct module_data *module, void *msg)
 	while (k_msgq_put(module->msg_q, msg, K_NO_WAIT) != 0) {
 		/* Message queue is full: purge old data & try again */
 		k_msgq_purge(module->msg_q);
-		LOG_WRN("Message queue full, queue purged");
+		LOG_WRN("%s: Message queue full, queue purged",
+			log_strdup(module->name));
+	}
+
+	if (IS_ENABLED(CONFIG_MODULES_COMMON_LOG_LEVEL_DBG)) {
+		struct event_prototype *evt_proto =
+			(struct event_prototype *)msg;
+		struct event_type *event =
+			(struct event_type *)evt_proto->header.type_id;
+		char buf[50];
+
+		event->log_event(&evt_proto->header, buf, sizeof(buf));
+
+		LOG_DBG("%s module: Enqueued: %s", log_strdup(module->name),
+			log_strdup(buf));
 	}
 }
 


### PR DESCRIPTION
Adds option to enable debug logging that shows which message type
is being enqueued and dequeued and in which module.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>