### PR TITLE
fix: define local data types to each module

### DIFF
--- a/src/cloud/cloud_codec/Kconfig
+++ b/src/cloud/cloud_codec/Kconfig
@@ -19,8 +19,8 @@ config SENSOR_BUFFER_MAX
 	int "Sensor data ringbuffer entries"
 	default 20
 
-config MODEM_BUFFER_MAX
-	int "Modem data ringbuffer entries"
+config MODEM_BUFFER_DYNAMIC_MAX
+	int "Dynamic modem data ringbuffer entries"
 	default 20
 
 config UI_BUFFER_MAX

--- a/src/cloud/cloud_codec/aws_iot_codec.c
+++ b/src/cloud/cloud_codec/aws_iot_codec.c
@@ -69,6 +69,7 @@ static int static_modem_data_add(cJSON *parent, struct cloud_data_modem *data)
 {
 	int err = 0;
 	char nw_mode[50];
+	int64_t mod_ts_prev = data->mod_ts;
 
 	static const char lte_string[] = "LTE-M";
 	static const char nbiot_string[] = "NB-IoT";
@@ -79,7 +80,7 @@ static int static_modem_data_add(cJSON *parent, struct cloud_data_modem *data)
 		goto exit;
 	}
 
-	err = date_time_uptime_to_unix_time_ms(&data->mod_ts_static);
+	err = date_time_uptime_to_unix_time_ms(&data->mod_ts);
 	if (err) {
 		LOG_ERR("date_time_uptime_to_unix_time_ms, error: %d", err);
 		return err;
@@ -112,8 +113,11 @@ static int static_modem_data_add(cJSON *parent, struct cloud_data_modem *data)
 	err += json_add_str(static_m_v, MODEM_APP_VERSION, data->appv);
 
 	err += json_add_obj(static_m, OBJECT_VALUE, static_m_v);
-	err += json_add_number(static_m, OBJECT_TIMESTAMP, data->mod_ts_static);
+	err += json_add_number(static_m, OBJECT_TIMESTAMP, data->mod_ts);
 	err += json_add_obj(parent, DATA_MODEM_STATIC, static_m);
+
+	/* Possible solution? */
+	data->mod_ts = mod_ts_prev;
 
 	if (err) {
 		return err;

--- a/src/cloud/cloud_codec/azure_iot_hub_codec.c
+++ b/src/cloud/cloud_codec/azure_iot_hub_codec.c
@@ -12,7 +12,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "cJSON.h"
-#include "cJSON_os.h"
 #include "json_aux.h"
 #include <date_time.h>
 
@@ -66,7 +65,8 @@ LOG_MODULE_REGISTER(cloud_codec, CONFIG_CLOUD_CODEC_LOG_LEVEL);
 #define DATA_GPS_HEADING	"hdg"
 
 /* Static functions */
-static int static_modem_data_add(cJSON *parent, struct cloud_data_modem *data)
+static int static_modem_data_add(cJSON *parent,
+				 struct cloud_data_modem_static *data)
 {
 	int err = 0;
 	char nw_mode[50];
@@ -80,7 +80,7 @@ static int static_modem_data_add(cJSON *parent, struct cloud_data_modem *data)
 		goto exit;
 	}
 
-	err = date_time_uptime_to_unix_time_ms(&data->mod_ts_static);
+	err = date_time_uptime_to_unix_time_ms(&data->ts);
 	if (err) {
 		LOG_ERR("date_time_uptime_to_unix_time_ms, error: %d", err);
 		return err;
@@ -112,7 +112,7 @@ static int static_modem_data_add(cJSON *parent, struct cloud_data_modem *data)
 	err += json_add_str(static_m_v, MODEM_BOARD, data->brdv);
 
 	err += json_add_obj(static_m, OBJECT_VALUE, static_m_v);
-	err += json_add_number(static_m, OBJECT_TIMESTAMP, data->mod_ts_static);
+	err += json_add_number(static_m, OBJECT_TIMESTAMP, data->ts);
 	err += json_add_obj(parent, DATA_MODEM_STATIC, static_m);
 
 	if (err) {
@@ -123,7 +123,8 @@ exit:
 	return 0;
 }
 
-static int dynamic_modem_data_add(cJSON *parent, struct cloud_data_modem *data,
+static int dynamic_modem_data_add(cJSON *parent,
+				  struct cloud_data_modem_dynamic *data,
 				  bool batch_entry)
 {
 	int err = 0;
@@ -134,7 +135,7 @@ static int dynamic_modem_data_add(cJSON *parent, struct cloud_data_modem *data,
 		goto exit;
 	}
 
-	err = date_time_uptime_to_unix_time_ms(&data->mod_ts);
+	err = date_time_uptime_to_unix_time_ms(&data->ts);
 	if (err) {
 		LOG_ERR("date_time_uptime_to_unix_time_ms, error: %d", err);
 		return err;
@@ -158,7 +159,7 @@ static int dynamic_modem_data_add(cJSON *parent, struct cloud_data_modem *data,
 	err += json_add_str(dynamic_m_v, MODEM_IP_ADDRESS, data->ip);
 
 	err += json_add_obj(dynamic_m, OBJECT_VALUE, dynamic_m_v);
-	err += json_add_number(dynamic_m, OBJECT_TIMESTAMP, data->mod_ts);
+	err += json_add_number(dynamic_m, OBJECT_TIMESTAMP, data->ts);
 
 	if (batch_entry) {
 		err += json_add_obj_array(parent, dynamic_m);
@@ -533,14 +534,14 @@ exit:
 int cloud_codec_encode_data(struct cloud_codec_data *output,
 			    struct cloud_data_gps *gps_buf,
 			    struct cloud_data_sensors *sensor_buf,
-			    struct cloud_data_modem *modem_buf,
+			    struct cloud_data_modem_static *modem_stat_buf,
+			    struct cloud_data_modem_dynamic *modem_dyn_buf,
 			    struct cloud_data_ui *ui_buf,
 			    struct cloud_data_accelerometer *mov_buf,
 			    struct cloud_data_battery *bat_buf)
 {
 	int err = 0;
 	char *buffer;
-	static bool initial_encode;
 	bool data_encoded = false;
 
 	cJSON *root_obj = cJSON_CreateObject();
@@ -555,16 +556,13 @@ int cloud_codec_encode_data(struct cloud_codec_data *output,
 		data_encoded = true;
 	}
 
-	if (modem_buf->queued) {
-		/* The first time modem data is sent to cloud upon a connection
-		 * we want to include static modem data.
-		 */
-		if (!initial_encode) {
-			err += static_modem_data_add(root_obj, modem_buf);
-				initial_encode = true;
-		}
+	if (modem_stat_buf->queued) {
+		err += static_modem_data_add(root_obj, modem_stat_buf);
+		data_encoded = true;
+	}
 
-		err += dynamic_modem_data_add(root_obj, modem_buf, false);
+	if (modem_dyn_buf->queued) {
+		err += dynamic_modem_data_add(root_obj, modem_dyn_buf, false);
 		data_encoded = true;
 	}
 
@@ -647,19 +645,20 @@ exit:
 	return err;
 }
 
-int cloud_codec_encode_batch_data(struct cloud_codec_data *output,
-				  struct cloud_data_gps *gps_buf,
-				  struct cloud_data_sensors *sensor_buf,
-				  struct cloud_data_modem *modem_buf,
-				  struct cloud_data_ui *ui_buf,
-				  struct cloud_data_accelerometer *accel_buf,
-				  struct cloud_data_battery *bat_buf,
-				  size_t gps_buf_count,
-				  size_t sensor_buf_count,
-				  size_t modem_buf_count,
-				  size_t ui_buf_count,
-				  size_t accel_buf_count,
-				  size_t bat_buf_count)
+int cloud_codec_encode_batch_data(
+				struct cloud_codec_data *output,
+				struct cloud_data_gps *gps_buf,
+				struct cloud_data_sensors *sensor_buf,
+				struct cloud_data_modem_dynamic *modem_dyn_buf,
+				struct cloud_data_ui *ui_buf,
+				struct cloud_data_accelerometer *accel_buf,
+				struct cloud_data_battery *bat_buf,
+				size_t gps_buf_count,
+				size_t sensor_buf_count,
+				size_t modem_dyn_buf_count,
+				size_t ui_buf_count,
+				size_t accel_buf_count,
+				size_t bat_buf_count)
 {
 	int err = 0;
 	char *buffer;
@@ -761,10 +760,10 @@ int cloud_codec_encode_batch_data(struct cloud_codec_data *output,
 	}
 
 	/* Dynamic modem data */
-	for (int i = 0; i < modem_buf_count; i++) {
-		if (modem_buf[i].queued) {
+	for (int i = 0; i < modem_dyn_buf_count; i++) {
+		if (modem_dyn_buf[i].queued) {
 			err += dynamic_modem_data_add(modem_obj,
-						     &modem_buf[i],
+						     &modem_dyn_buf[i],
 						     true);
 		}
 	}

--- a/src/cloud/cloud_codec/cloud_codec.h
+++ b/src/cloud/cloud_codec/cloud_codec.h
@@ -35,7 +35,7 @@ struct cloud_data_battery {
 	uint16_t bat;
 	/** Battery data timestamp. UNIX milliseconds. */
 	int64_t bat_ts;
-	/** Flag signifying that the data entry is to be published. */
+	/** Flag signifying that the data entry is to be encoded. */
 	bool queued;
 };
 
@@ -55,7 +55,7 @@ struct cloud_data_gps {
 	float spd;
 	/** Heading of movement in degrees. */
 	float hdg;
-	/** Flag signifying that the data entry is to be published. */
+	/** Flag signifying that the data entry is to be encoded. */
 	bool queued;
 };
 
@@ -90,17 +90,13 @@ struct cloud_data_sensors {
 	double temp;
 	/** Humidity level in percentage */
 	double hum;
-	/** Flag signifying that the data entry is to be published. */
+	/** Flag signifying that the data entry is to be encoded. */
 	bool queued;
 };
 
-struct cloud_data_modem {
-	/** Modem data timestamp. UNIX milliseconds. */
-	int64_t mod_ts;
-	/** Area code. */
-	uint16_t area;
-	/** Cell id. */
-	uint16_t cell;
+struct cloud_data_modem_static {
+	/** Static modem data timestamp. UNIX milliseconds. */
+	int64_t ts;
 	/** Band number. */
 	uint16_t bnd;
 	/** Network mode GPS. */
@@ -109,21 +105,32 @@ struct cloud_data_modem {
 	uint16_t nw_lte_m;
 	/** Network mode NB-IoT. */
 	uint16_t nw_nb_iot;
-	/** Reference Signal Received Power. */
-	uint16_t rsrp;
-	/** Internet Protocol Address. */
-	char *ip;
-	/* Mobile Country Code*/
-	char *mccmnc;
+	/** Integrated Circuit Card Identifier. */
+	char *iccid;
 	/** Application version and Mobile Network Code. */
 	char *appv;
 	/** Device board version. */
 	const char *brdv;
 	/** Modem firmware. */
 	char *fw;
-	/** Integrated Circuit Card Identifier. */
-	char *iccid;
-	/** Flag signifying that the data entry is to be published. */
+	/** Flag signifying that the data entry is to be encoded. */
+	bool queued;
+};
+
+struct cloud_data_modem_dynamic {
+	/** Dynamic modem data timestamp. UNIX milliseconds. */
+	int64_t ts;
+	/** Area code. */
+	uint16_t area;
+	/** Cell id. */
+	uint16_t cell;
+	/** Reference Signal Received Power. */
+	uint16_t rsrp;
+	/** Internet Protocol Address. */
+	char *ip;
+	/* Mobile Country Code*/
+	char *mccmnc;
+	/** Flag signifying that the data entry is to be encoded. */
 	bool queued;
 };
 
@@ -132,7 +139,7 @@ struct cloud_data_ui {
 	int btn;
 	/** Button data timestamp. UNIX milliseconds. */
 	int64_t btn_ts;
-	/** Flag signifying that the data entry is to be published. */
+	/** Flag signifying that the data entry is to be encoded. */
 	bool queued;
 };
 
@@ -156,7 +163,8 @@ int cloud_codec_encode_config(struct cloud_codec_data *output,
 int cloud_codec_encode_data(struct cloud_codec_data *output,
 			    struct cloud_data_gps *gps_buf,
 			    struct cloud_data_sensors *sensor_buf,
-			    struct cloud_data_modem *modem_buf,
+			    struct cloud_data_modem_static *modem_stat_buf,
+			    struct cloud_data_modem_dynamic *modem_dyn_buf,
 			    struct cloud_data_ui *ui_buf,
 			    struct cloud_data_accelerometer *accel_buf,
 			    struct cloud_data_battery *bat_buf);
@@ -164,19 +172,20 @@ int cloud_codec_encode_data(struct cloud_codec_data *output,
 int cloud_codec_encode_ui_data(struct cloud_codec_data *output,
 			       struct cloud_data_ui *ui_buf);
 
-int cloud_codec_encode_batch_data(struct cloud_codec_data *output,
-				  struct cloud_data_gps *gps_buf,
-				  struct cloud_data_sensors *sensor_buf,
-				  struct cloud_data_modem *modem_buf,
-				  struct cloud_data_ui *ui_buf,
-				  struct cloud_data_accelerometer *accel_buf,
-				  struct cloud_data_battery *bat_buf,
-				  size_t gps_buf_count,
-				  size_t sensor_buf_count,
-				  size_t modem_buf_count,
-				  size_t ui_buf_count,
-				  size_t accel_buf_count,
-				  size_t bat_buf_count);
+int cloud_codec_encode_batch_data(
+				struct cloud_codec_data *output,
+				struct cloud_data_gps *gps_buf,
+				struct cloud_data_sensors *sensor_buf,
+				struct cloud_data_modem_dynamic *modem_dyn_buf,
+				struct cloud_data_ui *ui_buf,
+				struct cloud_data_accelerometer *accel_buf,
+				struct cloud_data_battery *bat_buf,
+				size_t gps_buf_count,
+				size_t sensor_buf_count,
+				size_t modem_dyn_buf_count,
+				size_t ui_buf_count,
+				size_t accel_buf_count,
+				size_t bat_buf_count);
 
 void cloud_codec_populate_sensor_buffer(
 				struct cloud_data_sensors *sensor_buffer,
@@ -200,9 +209,10 @@ void cloud_codec_populate_gps_buffer(struct cloud_data_gps *gps_buffer,
 				     struct cloud_data_gps *new_gps_data,
 				     int *head_gps_buf);
 
-void cloud_codec_populate_modem_buffer(struct cloud_data_modem *modem_buffer,
-				       struct cloud_data_modem *new_modem_data,
-				       int *head_modem_buf);
+void cloud_codec_populate_modem_dynamic_buffer(
+				struct cloud_data_modem_dynamic *modem_buffer,
+				struct cloud_data_modem_dynamic *new_modem_data,
+				int *head_modem_buf);
 
 static inline void cloud_codec_release_data(struct cloud_codec_data *output)
 {

--- a/src/cloud/cloud_codec/cloud_codec.h
+++ b/src/cloud/cloud_codec/cloud_codec.h
@@ -95,10 +95,8 @@ struct cloud_data_sensors {
 };
 
 struct cloud_data_modem {
-	/** Dynamic modem data timestamp. UNIX milliseconds. */
+	/** Modem data timestamp. UNIX milliseconds. */
 	int64_t mod_ts;
-	/** Static modem data timestamp. UNIX milliseconds. */
-	int64_t mod_ts_static;
 	/** Area code. */
 	uint16_t area;
 	/** Cell id. */

--- a/src/cloud/cloud_codec/cloud_codec_ringbuffer.c
+++ b/src/cloud/cloud_codec/cloud_codec_ringbuffer.c
@@ -176,9 +176,10 @@ void cloud_codec_populate_gps_buffer(struct cloud_data_gps *gps_buffer,
 		CONFIG_GPS_BUFFER_MAX - 1);
 }
 
-void cloud_codec_populate_modem_buffer(struct cloud_data_modem *modem_buffer,
-				      struct cloud_data_modem *new_modem_data,
-				      int *head_modem_buf)
+void cloud_codec_populate_modem_dynamic_buffer(
+				struct cloud_data_modem_dynamic *modem_buffer,
+				struct cloud_data_modem_dynamic *new_modem_data,
+				int *head_modem_buf)
 {
 	if (!new_modem_data->queued) {
 		return;
@@ -186,12 +187,12 @@ void cloud_codec_populate_modem_buffer(struct cloud_data_modem *modem_buffer,
 
 	/* Go to start of buffer if end is reached. */
 	*head_modem_buf += 1;
-	if (*head_modem_buf == CONFIG_MODEM_BUFFER_MAX) {
+	if (*head_modem_buf == CONFIG_MODEM_BUFFER_DYNAMIC_MAX) {
 		*head_modem_buf = 0;
 	}
 
 	modem_buffer[*head_modem_buf] = *new_modem_data;
 
-	LOG_DBG("Entry: %d of %d in modem buffer filled", *head_modem_buf,
-		CONFIG_MODEM_BUFFER_MAX - 1);
+	LOG_DBG("Entry: %d of %d in dynamic modem buffer filled",
+		*head_modem_buf, CONFIG_MODEM_BUFFER_DYNAMIC_MAX - 1);
 }

--- a/src/cloud/cloud_codec/nrf_cloud_codec.c
+++ b/src/cloud/cloud_codec/nrf_cloud_codec.c
@@ -64,7 +64,8 @@ LOG_MODULE_REGISTER(cloud_codec, CONFIG_CLOUD_CODEC_LOG_LEVEL);
 #define DATA_GPS_HEADING	"hdg"
 
 /* Static functions */
-static int static_modem_data_add(cJSON *parent, struct cloud_data_modem *data)
+static int static_modem_data_add(cJSON *parent,
+				 struct cloud_data_modem_static *data)
 {
 	int err = 0;
 	char nw_mode[50];
@@ -78,7 +79,7 @@ static int static_modem_data_add(cJSON *parent, struct cloud_data_modem *data)
 		goto exit;
 	}
 
-	err = date_time_uptime_to_unix_time_ms(&data->mod_ts_static);
+	err = date_time_uptime_to_unix_time_ms(&data->ts);
 	if (err) {
 		LOG_ERR("date_time_uptime_to_unix_time_ms, error: %d", err);
 		return err;
@@ -111,18 +112,21 @@ static int static_modem_data_add(cJSON *parent, struct cloud_data_modem *data)
 	err += json_add_str(static_m_v, MODEM_APP_VERSION, data->appv);
 
 	err += json_add_obj(static_m, OBJECT_VALUE, static_m_v);
-	err += json_add_number(static_m, OBJECT_TIMESTAMP, data->mod_ts_static);
+	err += json_add_number(static_m, OBJECT_TIMESTAMP, data->ts);
 	err += json_add_obj(parent, DATA_MODEM_STATIC, static_m);
 
 	if (err) {
 		return err;
 	}
 
+	data->queued = false;
+
 exit:
 	return 0;
 }
 
-static int dynamic_modem_data_add(cJSON *parent, struct cloud_data_modem *data,
+static int dynamic_modem_data_add(cJSON *parent,
+				  struct cloud_data_modem_dynamic *data,
 				  bool batch_entry)
 {
 	int err = 0;
@@ -133,7 +137,7 @@ static int dynamic_modem_data_add(cJSON *parent, struct cloud_data_modem *data,
 		goto exit;
 	}
 
-	err = date_time_uptime_to_unix_time_ms(&data->mod_ts);
+	err = date_time_uptime_to_unix_time_ms(&data->ts);
 	if (err) {
 		LOG_ERR("date_time_uptime_to_unix_time_ms, error: %d", err);
 		return err;
@@ -157,7 +161,7 @@ static int dynamic_modem_data_add(cJSON *parent, struct cloud_data_modem *data,
 	err += json_add_str(dynamic_m_v, MODEM_IP_ADDRESS, data->ip);
 
 	err += json_add_obj(dynamic_m, OBJECT_VALUE, dynamic_m_v);
-	err += json_add_number(dynamic_m, OBJECT_TIMESTAMP, data->mod_ts);
+	err += json_add_number(dynamic_m, OBJECT_TIMESTAMP, data->ts);
 
 	if (batch_entry) {
 		err += json_add_obj_array(parent, dynamic_m);
@@ -431,7 +435,6 @@ int cloud_codec_decode_config(char *input, struct cloud_data_cfg *data)
 		json_print_obj("Decoded message:\n", root_obj);
 	}
 
-
 	group_obj = json_object_decode(root_obj, OBJECT_CONFIG);
 	if (group_obj != NULL) {
 		subgroup_obj = group_obj;
@@ -540,14 +543,14 @@ exit:
 int cloud_codec_encode_data(struct cloud_codec_data *output,
 			    struct cloud_data_gps *gps_buf,
 			    struct cloud_data_sensors *sensor_buf,
-			    struct cloud_data_modem *modem_buf,
+			    struct cloud_data_modem_static *modem_stat_buf,
+			    struct cloud_data_modem_dynamic *modem_dyn_buf,
 			    struct cloud_data_ui *ui_buf,
 			    struct cloud_data_accelerometer *mov_buf,
 			    struct cloud_data_battery *bat_buf)
 {
 	int err = 0;
 	char *buffer;
-	static bool initial_encode;
 	bool data_encoded = false;
 
 	cJSON *root_obj = cJSON_CreateObject();
@@ -566,16 +569,13 @@ int cloud_codec_encode_data(struct cloud_codec_data *output,
 		data_encoded = true;
 	}
 
-	if (modem_buf->queued) {
-		/* The first time modem data is sent to cloud upon a connection
-		 * we want to include static modem data.
-		 */
-		if (!initial_encode) {
-			err += static_modem_data_add(rep_obj, modem_buf);
-				initial_encode = true;
-		}
+	if (modem_stat_buf->queued) {
+		err += static_modem_data_add(rep_obj, modem_stat_buf);
+		data_encoded = true;
+	}
 
-		err += dynamic_modem_data_add(rep_obj, modem_buf, false);
+	if (modem_dyn_buf->queued) {
+		err += dynamic_modem_data_add(rep_obj, modem_dyn_buf, false);
 		data_encoded = true;
 	}
 
@@ -661,19 +661,20 @@ exit:
 	return err;
 }
 
-int cloud_codec_encode_batch_data(struct cloud_codec_data *output,
-				  struct cloud_data_gps *gps_buf,
-				  struct cloud_data_sensors *sensor_buf,
-				  struct cloud_data_modem *modem_buf,
-				  struct cloud_data_ui *ui_buf,
-				  struct cloud_data_accelerometer *accel_buf,
-				  struct cloud_data_battery *bat_buf,
-				  size_t gps_buf_count,
-				  size_t sensor_buf_count,
-				  size_t modem_buf_count,
-				  size_t ui_buf_count,
-				  size_t accel_buf_count,
-				  size_t bat_buf_count)
+int cloud_codec_encode_batch_data(
+				struct cloud_codec_data *output,
+				struct cloud_data_gps *gps_buf,
+				struct cloud_data_sensors *sensor_buf,
+				struct cloud_data_modem_dynamic *modem_dyn_buf,
+				struct cloud_data_ui *ui_buf,
+				struct cloud_data_accelerometer *accel_buf,
+				struct cloud_data_battery *bat_buf,
+				size_t gps_buf_count,
+				size_t sensor_buf_count,
+				size_t modem_dyn_buf_count,
+				size_t ui_buf_count,
+				size_t accel_buf_count,
+				size_t bat_buf_count)
 {
 	int err = 0;
 	char *buffer;
@@ -775,10 +776,10 @@ int cloud_codec_encode_batch_data(struct cloud_codec_data *output,
 	}
 
 	/* Dynamic modem data */
-	for (int i = 0; i < modem_buf_count; i++) {
-		if (modem_buf[i].queued) {
+	for (int i = 0; i < modem_dyn_buf_count; i++) {
+		if (modem_dyn_buf[i].queued) {
 			err += dynamic_modem_data_add(modem_obj,
-						     &modem_buf[i],
+						     &modem_dyn_buf[i],
 						     true);
 		}
 	}
@@ -797,9 +798,11 @@ int cloud_codec_encode_batch_data(struct cloud_codec_data *output,
 		goto exit;
 	}
 
-	buffer = cJSON_Print(root_obj);
+	buffer = cJSON_PrintUnformatted(root_obj);
 
-	printk("Encoded batch message: %s\n", buffer);
+	if (IS_ENABLED(CONFIG_CLOUD_CODEC_LOG_LEVEL_DBG)) {
+		json_print_obj("Encoded batch message:\n", root_obj);
+	}
 
 	output->buf = buffer;
 	output->len = strlen(buffer);

--- a/src/events/app_module_event.c
+++ b/src/events/app_module_event.c
@@ -15,8 +15,10 @@ static char *type2str(enum app_module_data_type type)
 		return "ENV";
 	case APP_DATA_MOVEMENT:
 		return "MOVE";
-	case APP_DATA_MODEM:
-		return "MODEM";
+	case APP_DATA_MODEM_STATIC:
+		return "MOD_STAT";
+	case APP_DATA_MODEM_DYNAMIC:
+		return "MOD_DYN";
 	case APP_DATA_BATTERY:
 		return "BAT";
 	case APP_DATA_GNSS:

--- a/src/events/app_module_event.h
+++ b/src/events/app_module_event.h
@@ -13,7 +13,6 @@
  * @{
  */
 
-#include "cloud/cloud_codec/cloud_codec.h"
 #include "event_manager.h"
 
 #ifdef __cplusplus

--- a/src/events/app_module_event.h
+++ b/src/events/app_module_event.h
@@ -67,7 +67,8 @@ enum app_module_event_type {
 enum app_module_data_type {
 	APP_DATA_ENVIRONMENTAL,
 	APP_DATA_MOVEMENT,
-	APP_DATA_MODEM,
+	APP_DATA_MODEM_STATIC,
+	APP_DATA_MODEM_DYNAMIC,
 	APP_DATA_BATTERY,
 	APP_DATA_GNSS,
 

--- a/src/events/gps_module_event.h
+++ b/src/events/gps_module_event.h
@@ -33,20 +33,13 @@ enum gps_module_event_type {
 };
 
 struct gps_module_data {
-	/** GPS data timestamp. UNIX milliseconds. */
-	int64_t gps_ts;
-	/** Longitude */
-	double longi;
-	/** Latitude */
-	double lat;
-	/** Altitude above WGS-84 ellipsoid in meters. */
-	float alt;
-	/** Accuracy in (2D 1-sigma) in meters. */
-	float acc;
-	/** Horizontal speed in meters. */
-	float spd;
-	/** Heading of movement in degrees. */
-	float hdg;
+	int64_t timestamp;
+	double longitude;
+	double latitude;
+	float altitude;
+	float accuracy;
+	float speed;
+	float heading;
 };
 
 /** @brief GPS event. */

--- a/src/events/gps_module_event.h
+++ b/src/events/gps_module_event.h
@@ -16,7 +16,6 @@
 #include <drivers/gps.h>
 
 #include "event_manager.h"
-#include "cloud/cloud_codec/cloud_codec.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -33,13 +32,30 @@ enum gps_module_event_type {
 	GPS_EVT_ERROR_CODE,
 };
 
+struct gps_module_data {
+	/** GPS data timestamp. UNIX milliseconds. */
+	int64_t gps_ts;
+	/** Longitude */
+	double longi;
+	/** Latitude */
+	double lat;
+	/** Altitude above WGS-84 ellipsoid in meters. */
+	float alt;
+	/** Accuracy in (2D 1-sigma) in meters. */
+	float acc;
+	/** Horizontal speed in meters. */
+	float spd;
+	/** Heading of movement in degrees. */
+	float hdg;
+};
+
 /** @brief GPS event. */
 struct gps_module_event {
 	struct event_header header;
 	enum gps_module_event_type type;
 
 	union {
-		struct cloud_data_gps gps;
+		struct gps_module_data gps;
 		struct gps_agps_request agps_request;
 		int err;
 	} data;

--- a/src/events/modem_module_event.c
+++ b/src/events/modem_module_event.c
@@ -33,8 +33,11 @@ static int log_modem_module_event(const struct event_header *eh, char *buf,
 	case MODEM_EVT_LTE_EDRX_UPDATE:
 		strcpy(event_name, "MODEM_EVT_LTE_EDRX_UPDATE");
 		break;
-	case MODEM_EVT_MODEM_DATA_READY:
-		strcpy(event_name, "MODEM_EVT_MODEM_DATA_READY");
+	case MODEM_EVT_MODEM_STATIC_DATA_READY:
+		strcpy(event_name, "MODEM_EVT_MODEM_STATIC_DATA_READY");
+		break;
+	case MODEM_EVT_MODEM_DYNAMIC_DATA_READY:
+		strcpy(event_name, "MODEM_EVT_MODEM_DYNAMIC_DATA_READY");
 		break;
 	case MODEM_EVT_BATTERY_DATA_READY:
 		strcpy(event_name, "MODEM_EVT_BATTERY_DATA_READY");

--- a/src/events/modem_module_event.h
+++ b/src/events/modem_module_event.h
@@ -27,7 +27,8 @@ enum modem_module_event_type {
 	MODEM_EVT_LTE_CELL_UPDATE,
 	MODEM_EVT_LTE_PSM_UPDATE,
 	MODEM_EVT_LTE_EDRX_UPDATE,
-	MODEM_EVT_MODEM_DATA_READY,
+	MODEM_EVT_MODEM_STATIC_DATA_READY,
+	MODEM_EVT_MODEM_DYNAMIC_DATA_READY,
 	MODEM_EVT_BATTERY_DATA_READY,
 	MODEM_EVT_SHUTDOWN_READY,
 	MODEM_EVT_ERROR
@@ -57,21 +58,25 @@ struct modem_module_edrx {
 	float ptw;
 };
 
-struct modem_module_modem_data {
+struct modem_module_static_modem_data {
 	int64_t timestamp;
-	uint16_t area_code;
-	uint16_t cell_id;
 	uint16_t band;
 	uint16_t nw_mode_gps;
 	uint16_t nw_mode_ltem;
 	uint16_t nw_mode_nbiot;
-	uint16_t rsrp;
-	char *ip_address;
-	char *mccmnc;
+	char *iccid;
 	char *app_version;
 	const char *board_version;
 	char *modem_fw;
-	char *iccid;
+};
+
+struct modem_module_dynamic_modem_data {
+	int64_t timestamp;
+	uint16_t area_code;
+	uint16_t cell_id;
+	uint16_t rsrp;
+	char *ip_address;
+	char *mccmnc;
 };
 
 struct modem_module_battery_data {
@@ -84,7 +89,8 @@ struct modem_module_event {
 	struct event_header header;
 	enum modem_module_event_type type;
 	union {
-		struct modem_module_modem_data modem;
+		struct modem_module_static_modem_data modem_static;
+		struct modem_module_dynamic_modem_data modem_dynamic;
 		struct modem_module_battery_data bat;
 		struct modem_module_cell cell;
 		struct modem_module_psm psm;

--- a/src/events/modem_module_event.h
+++ b/src/events/modem_module_event.h
@@ -14,7 +14,6 @@
  */
 
 #include "event_manager.h"
-#include "cloud/cloud_codec/cloud_codec.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -58,13 +57,53 @@ struct modem_module_edrx {
 	float ptw;
 };
 
+struct modem_module_modem_data {
+	/** Dynamic modem data timestamp. UNIX milliseconds. */
+	int64_t mod_ts;
+	/** Static modem data timestamp. UNIX milliseconds. */
+	int64_t mod_ts_static;
+	/** Area code. */
+	uint16_t area;
+	/** Cell id. */
+	uint16_t cell;
+	/** Band number. */
+	uint16_t bnd;
+	/** Network mode GPS. */
+	uint16_t nw_gps;
+	/** Network mode LTE-M. */
+	uint16_t nw_lte_m;
+	/** Network mode NB-IoT. */
+	uint16_t nw_nb_iot;
+	/** Reference Signal Received Power. */
+	uint16_t rsrp;
+	/** Internet Protocol Address. */
+	char *ip;
+	/* Mobile Country Code*/
+	char *mccmnc;
+	/** Application version and Mobile Network Code. */
+	char *appv;
+	/** Device board version. */
+	const char *brdv;
+	/** Modem firmware. */
+	char *fw;
+	/** Integrated Circuit Card Identifier. */
+	char *iccid;
+};
+
+struct modem_module_battery_data {
+	/** Battery voltage level. */
+	uint16_t bat;
+	/** Battery data timestamp. UNIX milliseconds. */
+	int64_t bat_ts;
+};
+
 /** @brief Modem event. */
 struct modem_module_event {
 	struct event_header header;
 	enum modem_module_event_type type;
 	union {
-		struct cloud_data_modem modem;
-		struct cloud_data_battery bat;
+		struct modem_module_modem_data modem;
+		struct modem_module_battery_data bat;
 		struct modem_module_cell cell;
 		struct modem_module_psm psm;
 		struct modem_module_edrx edrx;

--- a/src/events/modem_module_event.h
+++ b/src/events/modem_module_event.h
@@ -58,43 +58,25 @@ struct modem_module_edrx {
 };
 
 struct modem_module_modem_data {
-	/** Dynamic modem data timestamp. UNIX milliseconds. */
-	int64_t mod_ts;
-	/** Static modem data timestamp. UNIX milliseconds. */
-	int64_t mod_ts_static;
-	/** Area code. */
-	uint16_t area;
-	/** Cell id. */
-	uint16_t cell;
-	/** Band number. */
-	uint16_t bnd;
-	/** Network mode GPS. */
-	uint16_t nw_gps;
-	/** Network mode LTE-M. */
-	uint16_t nw_lte_m;
-	/** Network mode NB-IoT. */
-	uint16_t nw_nb_iot;
-	/** Reference Signal Received Power. */
+	int64_t timestamp;
+	uint16_t area_code;
+	uint16_t cell_id;
+	uint16_t band;
+	uint16_t nw_mode_gps;
+	uint16_t nw_mode_ltem;
+	uint16_t nw_mode_nbiot;
 	uint16_t rsrp;
-	/** Internet Protocol Address. */
-	char *ip;
-	/* Mobile Country Code*/
+	char *ip_address;
 	char *mccmnc;
-	/** Application version and Mobile Network Code. */
-	char *appv;
-	/** Device board version. */
-	const char *brdv;
-	/** Modem firmware. */
-	char *fw;
-	/** Integrated Circuit Card Identifier. */
+	char *app_version;
+	const char *board_version;
+	char *modem_fw;
 	char *iccid;
 };
 
 struct modem_module_battery_data {
-	/** Battery voltage level. */
-	uint16_t bat;
-	/** Battery data timestamp. UNIX milliseconds. */
-	int64_t bat_ts;
+	uint16_t battery_voltage;
+	int64_t timestamp;
 };
 
 /** @brief Modem event. */

--- a/src/events/sensor_module_event.c
+++ b/src/events/sensor_module_event.c
@@ -21,6 +21,9 @@ static int log_sensor_module_event(const struct event_header *eh, char *buf,
 	case SENSOR_EVT_ENVIRONMENTAL_DATA_READY:
 		strcpy(event_name, "SENSOR_EVT_ENVIRONMENTAL_DATA_READY");
 		break;
+	case SENSOR_EVT_ENVIRONMENTAL_NOT_SUPPORTED:
+		strcpy(event_name, "SENSOR_EVT_ENVIRONMENTAL_NOT_SUPPORTED");
+		break;
 	case SENSOR_EVT_SHUTDOWN_READY:
 		strcpy(event_name, "SENSOR_EVT_SHUTDOWN_READY");
 		break;

--- a/src/events/sensor_module_event.h
+++ b/src/events/sensor_module_event.h
@@ -14,18 +14,36 @@
  */
 
 #include "event_manager.h"
-#include "cloud/cloud_codec/cloud_codec.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+#define ACCELEROMETER_AXIS_COUNT 3
+
 /** @brief Sensor event types su bmitted by Sensor module. */
 enum sensor_module_event_types {
 	SENSOR_EVT_MOVEMENT_DATA_READY,
 	SENSOR_EVT_ENVIRONMENTAL_DATA_READY,
+	SENSOR_EVT_ENVIRONMENTAL_NOT_SUPPORTED,
 	SENSOR_EVT_SHUTDOWN_READY,
 	SENSOR_EVT_ERROR
+};
+
+struct sensor_module_data {
+	/** Environmental sensors timestamp. UNIX milliseconds. */
+	int64_t env_ts;
+	/** Temperature in celcius */
+	double temp;
+	/** Humidity level in percentage */
+	double hum;
+};
+
+struct sensor_module_accel_data {
+	/** Accelerometer readings timestamp. UNIX milliseconds. */
+	int64_t ts;
+	/** Accelerometer readings. */
+	double values[ACCELEROMETER_AXIS_COUNT];
 };
 
 /** @brief Sensor event. */
@@ -33,8 +51,8 @@ struct sensor_module_event {
 	struct event_header header;
 	enum sensor_module_event_types type;
 	union {
-		struct cloud_data_sensors sensors;
-		struct cloud_data_accelerometer accel;
+		struct sensor_module_data sensors;
+		struct sensor_module_accel_data accel;
 		int err;
 	} data;
 };

--- a/src/events/sensor_module_event.h
+++ b/src/events/sensor_module_event.h
@@ -31,18 +31,13 @@ enum sensor_module_event_types {
 };
 
 struct sensor_module_data {
-	/** Environmental sensors timestamp. UNIX milliseconds. */
-	int64_t env_ts;
-	/** Temperature in celcius */
-	double temp;
-	/** Humidity level in percentage */
-	double hum;
+	int64_t timestamp;
+	double temperature;
+	double humidity;
 };
 
 struct sensor_module_accel_data {
-	/** Accelerometer readings timestamp. UNIX milliseconds. */
-	int64_t ts;
-	/** Accelerometer readings. */
+	int64_t timestamp;
 	double values[ACCELEROMETER_AXIS_COUNT];
 };
 

--- a/src/events/ui_module_event.h
+++ b/src/events/ui_module_event.h
@@ -14,7 +14,6 @@
  */
 
 #include "event_manager.h"
-#include "cloud/cloud_codec/cloud_codec.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -27,13 +26,20 @@ enum ui_module_event_types {
 	UI_EVT_ERROR
 };
 
+struct ui_module_data {
+	/** Button number. */
+	int btn;
+	/** Button data timestamp. UNIX milliseconds. */
+	int64_t btn_ts;
+};
+
 /** @brief UI event. */
 struct ui_module_event {
 	struct event_header header;
 	enum ui_module_event_types type;
 
 	union {
-		struct cloud_data_ui ui;
+		struct ui_module_data ui;
 		int err;
 	} data;
 };

--- a/src/events/ui_module_event.h
+++ b/src/events/ui_module_event.h
@@ -27,10 +27,8 @@ enum ui_module_event_types {
 };
 
 struct ui_module_data {
-	/** Button number. */
-	int btn;
-	/** Button data timestamp. UNIX milliseconds. */
-	int64_t btn_ts;
+	int button_number;
+	int64_t timestamp;
 };
 
 /** @brief UI event. */

--- a/src/main.c
+++ b/src/main.c
@@ -233,12 +233,13 @@ static void data_get_init(void)
 	struct app_module_event *app_module_event = new_app_module_event();
 
 	/* Specify which data that is to be included in the transmission. */
-	app_module_event->data_list[0] = APP_DATA_MODEM;
-	app_module_event->data_list[1] = APP_DATA_BATTERY;
-	app_module_event->data_list[2] = APP_DATA_ENVIRONMENTAL;
+	app_module_event->data_list[0] = APP_DATA_MODEM_STATIC;
+	app_module_event->data_list[1] = APP_DATA_MODEM_DYNAMIC;
+	app_module_event->data_list[2] = APP_DATA_BATTERY;
+	app_module_event->data_list[3] = APP_DATA_ENVIRONMENTAL;
 
 	/* Set list count to number of data types passed in app_module_event. */
-	app_module_event->count = 3;
+	app_module_event->count = 4;
 	app_module_event->type = APP_EVT_DATA_GET;
 
 	/* Specify a timeout that each module has to fetch data. If data is not
@@ -254,7 +255,7 @@ static void data_get_all(void)
 	struct app_module_event *app_module_event = new_app_module_event();
 
 	/* Specify which data that is to be included in the transmission. */
-	app_module_event->data_list[0] = APP_DATA_MODEM;
+	app_module_event->data_list[0] = APP_DATA_MODEM_DYNAMIC;
 	app_module_event->data_list[1] = APP_DATA_BATTERY;
 	app_module_event->data_list[2] = APP_DATA_ENVIRONMENTAL;
 	app_module_event->data_list[3] = APP_DATA_GNSS;

--- a/src/main.c
+++ b/src/main.c
@@ -355,7 +355,7 @@ void on_sub_state_passive(struct app_msg_data *msg)
 	    (IS_EVENT(msg, ui, UI_EVT_BUTTON_DATA_READY))) {
 
 		if (IS_EVENT(msg, ui, UI_EVT_BUTTON_DATA_READY) &&
-		    msg->module.ui.data.ui.btn != 2) {
+		    msg->module.ui.data.ui.button_number != 2) {
 			return;
 		}
 

--- a/src/modules/data_module.c
+++ b/src/modules/data_module.c
@@ -691,8 +691,8 @@ static void on_all_states(struct data_msg_data *msg)
 
 	if (IS_EVENT(msg, ui, UI_EVT_BUTTON_DATA_READY)) {
 		struct cloud_data_ui new_ui_data = {
-			.btn = msg->module.ui.data.ui.btn,
-			.btn_ts = msg->module.ui.data.ui.btn_ts,
+			.btn = msg->module.ui.data.ui.button_number,
+			.btn_ts = msg->module.ui.data.ui.timestamp,
 			.queued = true
 		};
 
@@ -705,21 +705,19 @@ static void on_all_states(struct data_msg_data *msg)
 
 	if (IS_EVENT(msg, modem, MODEM_EVT_MODEM_DATA_READY)) {
 		struct cloud_data_modem new_modem_data = {
-			.appv = msg->module.modem.data.modem.appv,
-			.area = msg->module.modem.data.modem.area,
-			.bnd = msg->module.modem.data.modem.bnd,
-			.brdv = msg->module.modem.data.modem.brdv,
-			.cell = msg->module.modem.data.modem.cell,
-			.fw = msg->module.modem.data.modem.fw,
+			.appv = msg->module.modem.data.modem.app_version,
+			.area = msg->module.modem.data.modem.area_code,
+			.bnd = msg->module.modem.data.modem.band,
+			.brdv = msg->module.modem.data.modem.board_version,
+			.cell = msg->module.modem.data.modem.cell_id,
+			.fw = msg->module.modem.data.modem.modem_fw,
 			.iccid = msg->module.modem.data.modem.iccid,
-			.ip = msg->module.modem.data.modem.ip,
+			.ip = msg->module.modem.data.modem.ip_address,
 			.mccmnc = msg->module.modem.data.modem.mccmnc,
-			.mod_ts = msg->module.modem.data.modem.mod_ts,
-			.mod_ts_static =
-				msg->module.modem.data.modem.mod_ts_static,
-			.nw_gps = msg->module.modem.data.modem.nw_gps,
-			.nw_lte_m = msg->module.modem.data.modem.nw_lte_m,
-			.nw_nb_iot = msg->module.modem.data.modem.nw_nb_iot,
+			.mod_ts = msg->module.modem.data.modem.timestamp,
+			.nw_gps = msg->module.modem.data.modem.nw_mode_gps,
+			.nw_lte_m = msg->module.modem.data.modem.nw_mode_ltem,
+			.nw_nb_iot = msg->module.modem.data.modem.nw_mode_nbiot,
 			.rsrp = msg->module.modem.data.modem.rsrp,
 			.queued = true
 		};
@@ -732,8 +730,8 @@ static void on_all_states(struct data_msg_data *msg)
 
 	if (IS_EVENT(msg, modem, MODEM_EVT_BATTERY_DATA_READY)) {
 		struct cloud_data_battery new_battery_data = {
-			.bat = msg->module.modem.data.bat.bat,
-			.bat_ts = msg->module.modem.data.bat.bat_ts,
+			.bat = msg->module.modem.data.bat.battery_voltage,
+			.bat_ts = msg->module.modem.data.bat.timestamp,
 			.queued = true
 		};
 
@@ -745,9 +743,9 @@ static void on_all_states(struct data_msg_data *msg)
 
 	if (IS_EVENT(msg, sensor, SENSOR_EVT_ENVIRONMENTAL_DATA_READY)) {
 		struct cloud_data_sensors new_sensor_data = {
-			.temp = msg->module.sensor.data.sensors.temp,
-			.hum = msg->module.sensor.data.sensors.hum,
-			.env_ts = msg->module.sensor.data.sensors.env_ts,
+			.temp = msg->module.sensor.data.sensors.temperature,
+			.hum = msg->module.sensor.data.sensors.humidity,
+			.env_ts = msg->module.sensor.data.sensors.timestamp,
 			.queued = true
 		};
 
@@ -764,8 +762,10 @@ static void on_all_states(struct data_msg_data *msg)
 
 	if (IS_EVENT(msg, sensor, SENSOR_EVT_MOVEMENT_DATA_READY)) {
 		struct cloud_data_accelerometer new_movement_data = {
-			.values = {(bool)msg->module.sensor.data.accel.values},
-			.ts = msg->module.sensor.data.accel.ts,
+			.values[0] = msg->module.sensor.data.accel.values[0],
+			.values[1] = msg->module.sensor.data.accel.values[1],
+			.values[2] = msg->module.sensor.data.accel.values[2],
+			.ts = msg->module.sensor.data.accel.timestamp,
 			.queued = true
 		};
 
@@ -775,13 +775,13 @@ static void on_all_states(struct data_msg_data *msg)
 
 	if (IS_EVENT(msg, gps, GPS_EVT_DATA_READY)) {
 		struct cloud_data_gps new_gps_data = {
-			.acc = msg->module.gps.data.gps.acc,
-			.alt = msg->module.gps.data.gps.alt,
-			.hdg = msg->module.gps.data.gps.hdg,
-			.lat = msg->module.gps.data.gps.lat,
-			.longi = msg->module.gps.data.gps.longi,
-			.spd = msg->module.gps.data.gps.spd,
-			.gps_ts = msg->module.gps.data.gps.gps_ts,
+			.acc = msg->module.gps.data.gps.accuracy,
+			.alt = msg->module.gps.data.gps.altitude,
+			.hdg = msg->module.gps.data.gps.heading,
+			.lat = msg->module.gps.data.gps.latitude,
+			.longi = msg->module.gps.data.gps.longitude,
+			.spd = msg->module.gps.data.gps.speed,
+			.gps_ts = msg->module.gps.data.gps.timestamp,
 			.queued = true
 		};
 

--- a/src/modules/gps_module.c
+++ b/src/modules/gps_module.c
@@ -119,13 +119,13 @@ static void gps_data_send(struct gps_pvt *gps_data)
 {
 	struct gps_module_event *gps_module_event = new_gps_module_event();
 
-	gps_module_event->data.gps.longi = gps_data->longitude;
-	gps_module_event->data.gps.lat = gps_data->latitude;
-	gps_module_event->data.gps.alt = gps_data->altitude;
-	gps_module_event->data.gps.acc = gps_data->accuracy;
-	gps_module_event->data.gps.spd = gps_data->speed;
-	gps_module_event->data.gps.hdg = gps_data->heading;
-	gps_module_event->data.gps.gps_ts = k_uptime_get();
+	gps_module_event->data.gps.longitude = gps_data->longitude;
+	gps_module_event->data.gps.latitude = gps_data->latitude;
+	gps_module_event->data.gps.altitude = gps_data->altitude;
+	gps_module_event->data.gps.accuracy = gps_data->accuracy;
+	gps_module_event->data.gps.speed = gps_data->speed;
+	gps_module_event->data.gps.heading = gps_data->heading;
+	gps_module_event->data.gps.timestamp = k_uptime_get();
 	gps_module_event->type = GPS_EVT_DATA_READY;
 
 	EVENT_SUBMIT(gps_module_event);

--- a/src/modules/gps_module.c
+++ b/src/modules/gps_module.c
@@ -126,7 +126,6 @@ static void gps_data_send(struct gps_pvt *gps_data)
 	gps_module_event->data.gps.spd = gps_data->speed;
 	gps_module_event->data.gps.hdg = gps_data->heading;
 	gps_module_event->data.gps.gps_ts = k_uptime_get();
-	gps_module_event->data.gps.queued = true;
 	gps_module_event->type = GPS_EVT_DATA_READY;
 
 	EVENT_SUBMIT(gps_module_event);

--- a/src/modules/modem_module.c
+++ b/src/modules/modem_module.c
@@ -278,7 +278,6 @@ static int modem_data_get(void)
 		modem_param.network.current_band.value;
 	modem_module_event->data.modem.mod_ts = k_uptime_get();
 	modem_module_event->data.modem.mod_ts_static = k_uptime_get();
-	modem_module_event->data.modem.queued = true;
 	modem_module_event->type = MODEM_EVT_MODEM_DATA_READY;
 
 	EVENT_SUBMIT(modem_module_event);
@@ -328,7 +327,6 @@ static int battery_data_get(void)
 
 	modem_module_event->data.bat.bat = modem_param.device.battery.value;
 	modem_module_event->data.bat.bat_ts = k_uptime_get();
-	modem_module_event->data.bat.queued = true;
 	modem_module_event->type = MODEM_EVT_BATTERY_DATA_READY;
 
 	EVENT_SUBMIT(modem_module_event);

--- a/src/modules/modem_module.c
+++ b/src/modules/modem_module.c
@@ -254,30 +254,33 @@ static int modem_data_get(void)
 	struct modem_module_event *modem_module_event =
 			new_modem_module_event();
 
-	modem_module_event->data.modem.rsrp = rsrp_value_latest;
-	modem_module_event->data.modem.ip =
-		modem_param.network.ip_address.value_string;
-	modem_module_event->data.modem.cell = modem_param.network.cellid_dec;
+	modem_module_event->data.modem.rsrp =
+			rsrp_value_latest;
+	modem_module_event->data.modem.ip_address =
+			modem_param.network.ip_address.value_string;
+	modem_module_event->data.modem.cell_id =
+			modem_param.network.cellid_dec;
 	modem_module_event->data.modem.mccmnc =
 		modem_param.network.current_operator.value_string;
-	modem_module_event->data.modem.area =
+	modem_module_event->data.modem.area_code =
 			modem_param.network.area_code.value;
-	modem_module_event->data.modem.appv = CONFIG_CAT_TRACKER_APP_VERSION;
-	modem_module_event->data.modem.brdv = modem_param.device.board;
-	modem_module_event->data.modem.fw =
+	modem_module_event->data.modem.app_version =
+			CONFIG_CAT_TRACKER_APP_VERSION;
+	modem_module_event->data.modem.board_version =
+			modem_param.device.board;
+	modem_module_event->data.modem.modem_fw =
 		modem_param.device.modem_fw.value_string;
 	modem_module_event->data.modem.iccid =
 			modem_param.sim.iccid.value_string;
-	modem_module_event->data.modem.nw_lte_m =
+	modem_module_event->data.modem.nw_mode_ltem =
 		modem_param.network.lte_mode.value;
-	modem_module_event->data.modem.nw_nb_iot =
+	modem_module_event->data.modem.nw_mode_nbiot =
 		modem_param.network.nbiot_mode.value;
-	modem_module_event->data.modem.nw_gps =
+	modem_module_event->data.modem.nw_mode_gps =
 			modem_param.network.gps_mode.value;
-	modem_module_event->data.modem.bnd =
+	modem_module_event->data.modem.band =
 		modem_param.network.current_band.value;
-	modem_module_event->data.modem.mod_ts = k_uptime_get();
-	modem_module_event->data.modem.mod_ts_static = k_uptime_get();
+	modem_module_event->data.modem.timestamp = k_uptime_get();
 	modem_module_event->type = MODEM_EVT_MODEM_DATA_READY;
 
 	EVENT_SUBMIT(modem_module_event);
@@ -325,8 +328,9 @@ static int battery_data_get(void)
 	struct modem_module_event *modem_module_event =
 			new_modem_module_event();
 
-	modem_module_event->data.bat.bat = modem_param.device.battery.value;
-	modem_module_event->data.bat.bat_ts = k_uptime_get();
+	modem_module_event->data.bat.battery_voltage =
+			modem_param.device.battery.value;
+	modem_module_event->data.bat.timestamp = k_uptime_get();
 	modem_module_event->type = MODEM_EVT_BATTERY_DATA_READY;
 
 	EVENT_SUBMIT(modem_module_event);

--- a/src/modules/sensor_module.c
+++ b/src/modules/sensor_module.c
@@ -91,8 +91,7 @@ static void movement_data_send(const struct ext_sensor_evt *const acc_data)
 				acc_data->value_array[1];
 		sensor_module_event->data.accel.values[2] =
 				acc_data->value_array[2];
-		sensor_module_event->data.accel.ts = k_uptime_get();
-		sensor_module_event->data.accel.queued = true;
+		sensor_module_event->data.accel.timestamp = k_uptime_get();
 		sensor_module_event->type = SENSOR_EVT_MOVEMENT_DATA_READY;
 
 		EVENT_SUBMIT(sensor_module_event);
@@ -134,10 +133,9 @@ static int environmental_data_get(void)
 	}
 
 	sensor_module_event = new_sensor_module_event();
-	sensor_module_event->data.sensors.env_ts = k_uptime_get();
-	sensor_module_event->data.sensors.temp = temp;
-	sensor_module_event->data.sensors.hum = hum;
-	sensor_module_event->data.sensors.queued = true;
+	sensor_module_event->data.sensors.timestamp = k_uptime_get();
+	sensor_module_event->data.sensors.temperature = temp;
+	sensor_module_event->data.sensors.humidity = hum;
 	sensor_module_event->type = SENSOR_EVT_ENVIRONMENTAL_DATA_READY;
 #else
 
@@ -152,8 +150,7 @@ static int environmental_data_get(void)
 	 * This makes sure that the entry is not stored in the circular buffer.
 	 */
 	sensor_module_event = new_sensor_module_event();
-	sensor_module_event->data.sensors.queued = false;
-	sensor_module_event->type = SENSOR_EVT_ENVIRONMENTAL_DATA_READY;
+	sensor_module_event->type = SENSOR_EVT_ENVIRONMENTAL_NOT_SUPPORTED;
 #endif
 	EVENT_SUBMIT(sensor_module_event);
 

--- a/src/modules/ui_module.c
+++ b/src/modules/ui_module.c
@@ -40,8 +40,8 @@ static void button_handler(uint32_t button_states, uint32_t has_changed)
 				new_ui_module_event();
 
 		ui_module_event->type = UI_EVT_BUTTON_DATA_READY;
-		ui_module_event->data.ui.btn = 1;
-		ui_module_event->data.ui.btn_ts = k_uptime_get();
+		ui_module_event->data.ui.button_number = 1;
+		ui_module_event->data.ui.timestamp = k_uptime_get();
 
 		EVENT_SUBMIT(ui_module_event);
 	}
@@ -53,8 +53,8 @@ static void button_handler(uint32_t button_states, uint32_t has_changed)
 				new_ui_module_event();
 
 		ui_module_event->type = UI_EVT_BUTTON_DATA_READY;
-		ui_module_event->data.ui.btn = 2;
-		ui_module_event->data.ui.btn_ts = k_uptime_get();
+		ui_module_event->data.ui.button_number = 2;
+		ui_module_event->data.ui.timestamp = k_uptime_get();
 
 		EVENT_SUBMIT(ui_module_event);
 


### PR DESCRIPTION
 - define local data types for data sent from the module
 - Make so that modules only transmit their own events, no mimic.
 - Split modem data into static and dynamic modem data.