### PR TITLE
fix: remove init and running state from output modules

### DIFF
--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -8,6 +8,7 @@
 
 #include "ui.h"
 #include "led_pwm.h"
+#include <device.h>
 
 LOG_MODULE_REGISTER(ui, CONFIG_UI_LOG_LEVEL);
 
@@ -78,8 +79,10 @@ enum ui_led_pattern ui_led_get_pattern(void)
 	return current_led_state;
 }
 
-int ui_init(void)
+static int ui_init(const struct device *dev)
 {
+	ARG_UNUSED(dev);
+
 	int err = 0;
 
 #ifdef CONFIG_UI_LED_USE_PWM
@@ -114,3 +117,5 @@ void ui_stop_leds(void)
 	ui_leds_stop();
 #endif
 }
+
+SYS_INIT(ui_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);

--- a/src/ui/ui.h
+++ b/src/ui/ui.h
@@ -111,15 +111,6 @@ enum ui_led_pattern {
 };
 
 /**
- * @brief Initializes the user interface module.
- *
- * @param cb UI callback handler. Can be NULL to disable callbacks.
- *
- * @return 0 on success or negative error value on failure.
- */
-int ui_init(void);
-
-/**
  * @brief Sets the LED pattern.
  *
  * @param pattern LED pattern.


### PR DESCRIPTION
 - Statically initialize delayed work items
 - System init UI library
 - add IS_EVENT macro to check event header types
 - remove output prefixed static variables
 - remove setup() function. No longer needed when dependecies and
   kernel items are statically initialized.

Signed-off-by: Simen S. Røstad <simen.rostad@nordicsemi.no>