### PR TITLE
modules: Return error and send event if message queue is full

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -162,68 +162,65 @@ static void sub_state_set(enum sub_state_type new_state)
  */
 static bool event_handler(const struct event_header *eh)
 {
-	if (is_cloud_module_event(eh)) {
-		struct cloud_module_event *event = cast_cloud_module_event(eh);
-		struct app_msg_data app_msg = {
-			.module.cloud = *event
-		};
+	struct app_msg_data msg = {0};
+	bool enqueue_msg = false;
 
-		module_enqueue_msg(&self, &app_msg);
+	if (is_cloud_module_event(eh)) {
+		struct cloud_module_event *evt = cast_cloud_module_event(eh);
+
+		msg.module.cloud = *evt;
+		enqueue_msg = true;
 	}
 
 	if (is_app_module_event(eh)) {
-		struct app_module_event *event = cast_app_module_event(eh);
-		struct app_msg_data app_msg = {
-			.module.app = *event
-		};
+		struct app_module_event *evt = cast_app_module_event(eh);
 
-		module_enqueue_msg(&self, &app_msg);
+		msg.module.app = *evt;
+		enqueue_msg = true;
 	}
 
 	if (is_data_module_event(eh)) {
-		struct data_module_event *event = cast_data_module_event(eh);
-		struct app_msg_data app_msg = {
-			.module.data = *event
-		};
+		struct data_module_event *evt = cast_data_module_event(eh);
 
-		module_enqueue_msg(&self, &app_msg);
+		msg.module.data = *evt;
+		enqueue_msg = true;
 	}
 
 	if (is_sensor_module_event(eh)) {
-		struct sensor_module_event *event =
-				cast_sensor_module_event(eh);
-		struct app_msg_data app_msg = {
-			.module.sensor = *event
-		};
+		struct sensor_module_event *evt = cast_sensor_module_event(eh);
 
-		module_enqueue_msg(&self, &app_msg);
+		msg.module.sensor = *evt;
+		enqueue_msg = true;
 	}
 
 	if (is_util_module_event(eh)) {
-		struct util_module_event *event = cast_util_module_event(eh);
-		struct app_msg_data app_msg = {
-			.module.util = *event
-		};
+		struct util_module_event *evt = cast_util_module_event(eh);
 
-		module_enqueue_msg(&self, &app_msg);
+		msg.module.util = *evt;
+		enqueue_msg = true;
 	}
 
 	if (is_modem_module_event(eh)) {
-		struct modem_module_event *event = cast_modem_module_event(eh);
-		struct app_msg_data app_msg = {
-			.module.modem = *event
-		};
+		struct modem_module_event *evt = cast_modem_module_event(eh);
 
-		module_enqueue_msg(&self, &app_msg);
+		msg.module.modem = *evt;
+		enqueue_msg = true;
 	}
 
 	if (is_ui_module_event(eh)) {
-		struct ui_module_event *event = cast_ui_module_event(eh);
-		struct app_msg_data app_msg = {
-			.module.ui = *event
-		};
+		struct ui_module_event *evt = cast_ui_module_event(eh);
 
-		module_enqueue_msg(&self, &app_msg);
+		msg.module.ui = *evt;
+		enqueue_msg = true;
+	}
+
+	if (enqueue_msg) {
+		int err = module_enqueue_msg(&self, &msg);
+
+		if (err) {
+			LOG_ERR("Message could not be enqueued");
+			SEND_ERROR(app, APP_EVT_ERROR, err);
+		}
 	}
 
 	return false;

--- a/src/modules/cloud_module.c
+++ b/src/modules/cloud_module.c
@@ -147,58 +147,58 @@ static void sub_state_set(enum sub_state_type new_state)
 /* Handlers */
 static bool event_handler(const struct event_header *eh)
 {
-	if (is_app_module_event(eh)) {
-		struct app_module_event *event = cast_app_module_event(eh);
-		struct cloud_msg_data msg = {
-			.module.app = *event
-		};
+	struct cloud_msg_data msg = {0};
+	bool enqueue_msg = false;
 
-		module_enqueue_msg(&self, &msg);
+	if (is_app_module_event(eh)) {
+		struct app_module_event *evt = cast_app_module_event(eh);
+
+		msg.module.app = *evt;
+		enqueue_msg = true;
 	}
 
 	if (is_data_module_event(eh)) {
-		struct data_module_event *event = cast_data_module_event(eh);
-		struct cloud_msg_data msg = {
-			.module.data = *event
-		};
+		struct data_module_event *evt = cast_data_module_event(eh);
 
-		module_enqueue_msg(&self, &msg);
+		msg.module.data = *evt;
+		enqueue_msg = true;
 	}
 
 	if (is_modem_module_event(eh)) {
-		struct modem_module_event *event = cast_modem_module_event(eh);
-		struct cloud_msg_data msg = {
-			.module.modem = *event
-		};
+		struct modem_module_event *evt = cast_modem_module_event(eh);
 
-		module_enqueue_msg(&self, &msg);
+		msg.module.modem = *evt;
+		enqueue_msg = true;
 	}
 
 	if (is_cloud_module_event(eh)) {
-		struct cloud_module_event *event = cast_cloud_module_event(eh);
-		struct cloud_msg_data msg = {
-			.module.cloud = *event
-		};
+		struct cloud_module_event *evt = cast_cloud_module_event(eh);
 
-		module_enqueue_msg(&self, &msg);
+		msg.module.cloud = *evt;
+		enqueue_msg = true;
 	}
 
 	if (is_util_module_event(eh)) {
-		struct util_module_event *event = cast_util_module_event(eh);
-		struct cloud_msg_data msg = {
-			.module.util = *event
-		};
+		struct util_module_event *evt = cast_util_module_event(eh);
 
-		module_enqueue_msg(&self, &msg);
+		msg.module.util = *evt;
+		enqueue_msg = true;
 	}
 
 	if (is_gps_module_event(eh)) {
-		struct gps_module_event *event = cast_gps_module_event(eh);
-		struct cloud_msg_data msg = {
-			.module.gps = *event
-		};
+		struct gps_module_event *evt = cast_gps_module_event(eh);
 
-		module_enqueue_msg(&self, &msg);
+		msg.module.gps = *evt;
+		enqueue_msg = true;
+	}
+
+	if (enqueue_msg) {
+		int err = module_enqueue_msg(&self, &msg);
+
+		if (err) {
+			LOG_ERR("Message could not be enqueued");
+			SEND_ERROR(cloud, CLOUD_EVT_ERROR, err);
+		}
 	}
 
 	return false;

--- a/src/modules/data_module.c
+++ b/src/modules/data_module.c
@@ -165,77 +165,73 @@ static void state_set(enum state_type new_state)
 /* Handlers */
 static bool event_handler(const struct event_header *eh)
 {
+	struct data_msg_data msg = {0};
+	bool enqueue_msg = false;
+
 	if (is_modem_module_event(eh)) {
 		struct modem_module_event *event = cast_modem_module_event(eh);
-		struct data_msg_data data_msg = {
-			.module.modem = *event
-		};
 
-		module_enqueue_msg(&self, &data_msg);
+		msg.module.modem = *event;
+		enqueue_msg = true;
 	}
 
 	if (is_cloud_module_event(eh)) {
 		struct cloud_module_event *event = cast_cloud_module_event(eh);
-		struct data_msg_data data_msg = {
-			.module.cloud = *event
-		};
 
-		module_enqueue_msg(&self, &data_msg);
+		msg.module.cloud = *event;
+		enqueue_msg = true;
 	}
 
 	if (is_gps_module_event(eh)) {
 		struct gps_module_event *event = cast_gps_module_event(eh);
-		struct data_msg_data data_msg = {
-			.module.gps = *event
-		};
 
-		module_enqueue_msg(&self, &data_msg);
+		msg.module.gps = *event;
+		enqueue_msg = true;
 	}
 
 	if (is_sensor_module_event(eh)) {
 		struct sensor_module_event *event =
 				cast_sensor_module_event(eh);
-		struct data_msg_data data_msg = {
-			.module.sensor = *event
-		};
 
-		module_enqueue_msg(&self, &data_msg);
+		msg.module.sensor = *event;
+		enqueue_msg = true;
 	}
 
 	if (is_ui_module_event(eh)) {
 		struct ui_module_event *event = cast_ui_module_event(eh);
-		struct data_msg_data data_msg = {
-			.module.ui = *event
-		};
 
-		module_enqueue_msg(&self, &data_msg);
+		msg.module.ui = *event;
+		enqueue_msg = true;
 	}
 
 	if (is_app_module_event(eh)) {
 		struct app_module_event *event = cast_app_module_event(eh);
-		struct data_msg_data data_msg = {
-			.module.app = *event
-		};
 
-		module_enqueue_msg(&self, &data_msg);
+		msg.module.app = *event;
+		enqueue_msg = true;
 	}
 
 	if (is_data_module_event(eh)) {
 		struct data_module_event *event = cast_data_module_event(eh);
-		struct data_msg_data data_msg = {
-			.module.data = *event
-		};
 
-		module_enqueue_msg(&self, &data_msg);
+		msg.module.data = *event;
+		enqueue_msg = true;
 	}
 
 	if (is_util_module_event(eh)) {
 		struct util_module_event *event = cast_util_module_event(eh);
-		struct data_msg_data data_msg = {
-			.module.util = *event
-		};
 
-		module_enqueue_msg(&self, &data_msg);
+		msg.module.util = *event;
+		enqueue_msg = true;
+	}
+
+	if (enqueue_msg) {
+		int err = module_enqueue_msg(&self, &msg);
+
+		if (err) {
+			LOG_ERR("Message could not be enqueued");
+			SEND_ERROR(data, DATA_EVT_ERROR, err);
+		}
 	}
 
 	return false;

--- a/src/modules/modules_common.h
+++ b/src/modules/modules_common.h
@@ -38,7 +38,11 @@ void module_set_queue(struct module_data *module,  struct k_msgq *msg_q);
 
 int module_get_next_msg(struct module_data *module, void *msg);
 
-void module_enqueue_msg(struct module_data *module, void *msg);
+/** @brief Enqueue message to a module's queue.
+ *
+ *  @return 0 if successful, otherwise a negative error code.
+ */
+int module_enqueue_msg(struct module_data *module, void *msg);
 
 void module_start(struct module_data *module);
 


### PR DESCRIPTION
- Return error code from module_enqueue_msg() to let modules act on it
- Send error event from modules if module_enqueue_msg() fails, as that
  may lead to the module get into undefined state.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>